### PR TITLE
Added new search using typesense

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
       # Install and build Docusaurus website
       - name: Build Docusaurus website
         run: |
-          npm install 
+          npm install --legacy-peer-deps
           npm run build
       - name: Deploy to gh-pages
         uses: JamesIves/github-pages-deploy-action@4.1.4

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -16,6 +16,28 @@ const config = {
         textColor: '#091E42',
         isCloseable: false,
       },*/
+    typesense: {
+      // Replace this with the name of your index/collection.
+      // It should match the "index_name" entry in the scraper's "config.json" file.
+      typesenseCollectionName: 'Odysee Help',
+
+      typesenseServerConfig: {
+        nodes: [
+          {
+            host: 'typesense-search.odysee.tv',
+            port: 443,
+            protocol: 'https',
+          }
+        ],
+        apiKey: '4GTsCd3uCubegfQOZKE9z6k39LGulcrg',
+      },
+
+      // Optional: Typesense search parameters: https://typesense.org/docs/0.24.0/api/search.html#search-parameters
+      typesenseSearchParameters: {},
+
+      // Optional
+      contextualSearch: true,
+    },
       metadata: [{name: 'keywords', content: 'odysee, help, help hub, support'}],
       navbar: {
         title: '',
@@ -167,23 +189,7 @@ const config = {
       };
     },
   ],
-  themes: [
-    [
-      require.resolve("@easyops-cn/docusaurus-search-local"),
-      {
-        hashed: true,
-		indexBlog: false,
-		docsRouteBasePath: "/",
-		docsDir: "docs",
-        language: ['en', 'es', 'fr', 'de', 'pt'],
-		searchBarShortcutHint: false,
-		explicitSearchResultPath: true,
-		removeDefaultStemmer: true,
-		removeDefaultStopWordFilter: true,
-		explicitSearchResultPath: true,
-      },
-    ],
-  ],
+  themes: ['docusaurus-theme-search-typesense'],
   presets: [
     [
       'classic',

--- a/i18n/de/code.json
+++ b/i18n/de/code.json
@@ -5,7 +5,7 @@
   },
   "theme.ErrorPageContent.tryAgain": {
     "message": "Nochmal versuchen",
-    "description": "The label of the button to try again when the page crashed"
+    "description": "The label of the button to try again rendering when the React error boundary captures an error"
   },
   "theme.NotFound.title": {
     "message": "Seite nicht gefunden",
@@ -299,5 +299,129 @@
   "theme.tags.tagsPageTitle": {
     "message": "Tags",
     "description": "The title of the tag list page"
+  },
+  "theme.NavBar.navAriaLabel": {
+    "message": "Main",
+    "description": "The ARIA label for the main navigation"
+  },
+  "theme.docs.sidebar.navAriaLabel": {
+    "message": "Docs sidebar",
+    "description": "The ARIA label for the sidebar navigation"
+  },
+  "theme.docs.sidebar.closeSidebarButtonAriaLabel": {
+    "message": "Close navigation bar",
+    "description": "The ARIA label for close button of mobile sidebar"
+  },
+  "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
+    "message": "Toggle navigation bar",
+    "description": "The ARIA label for hamburger menu button of mobile navigation"
+  },
+  "theme.SearchPage.inputPlaceholder": {
+    "message": "Gib deine Suche hier ein",
+    "description": "The placeholder for search page input"
+  },
+  "theme.SearchPage.inputLabel": {
+    "message": "Suchen",
+    "description": "The ARIA label for search page input"
+  },
+  "theme.SearchPage.typesenseLabel": {
+    "message": "Suche bereitgestellt von Typesense",
+    "description": "The ARIA label for Typesense mention"
+  },
+  "theme.SearchPage.fetchingNewResults": {
+    "message": "Neue Ergebnisse werden abgerufen...",
+    "description": "The paragraph for fetching new search results"
+  },
+  "theme.SearchModal.searchBox.resetButtonTitle": {
+    "message": "Eingabe löschen",
+    "description": "The label and ARIA label for search box reset button"
+  },
+  "theme.SearchModal.searchBox.cancelButtonText": {
+    "message": "Abbrechen",
+    "description": "The label and ARIA label for search box cancel button"
+  },
+  "theme.SearchModal.startScreen.recentSearchesTitle": {
+    "message": "Kürzlich gesucht",
+    "description": "The title for recent searches"
+  },
+  "theme.SearchModal.startScreen.noRecentSearchesText": {
+    "message": "Keine kürzlich ausgeführten Suchanfragen",
+    "description": "The text when no recent searches"
+  },
+  "theme.SearchModal.startScreen.saveRecentSearchButtonTitle": {
+    "message": "Diese Suche speichern",
+    "description": "The label for save recent search button"
+  },
+  "theme.SearchModal.startScreen.removeRecentSearchButtonTitle": {
+    "message": "Diese Suchanfrage aus dem Verlauf löschen",
+    "description": "The label for remove recent search button"
+  },
+  "theme.SearchModal.startScreen.favoriteSearchesTitle": {
+    "message": "Favorit",
+    "description": "The title for favorite searches"
+  },
+  "theme.SearchModal.startScreen.removeFavoriteSearchButtonTitle": {
+    "message": "Entferne diese Suche aus den Favoriten",
+    "description": "The label for remove favorite search button"
+  },
+  "theme.SearchModal.errorScreen.titleText": {
+    "message": "Ergebnisse können nicht abgerufen werden",
+    "description": "The title for error screen of search modal"
+  },
+  "theme.SearchModal.errorScreen.helpText": {
+    "message": "Ein Fehler ist aufgetreten, prüfe deine Netzwerkverbindung.",
+    "description": "The help text for error screen of search modal"
+  },
+  "theme.SearchModal.footer.selectText": {
+    "message": "zum Auswählen",
+    "description": "The explanatory text of the action for the enter key"
+  },
+  "theme.SearchModal.footer.selectKeyAriaLabel": {
+    "message": "Enter-Taste",
+    "description": "The ARIA label for the Enter key button that makes the selection"
+  },
+  "theme.SearchModal.footer.navigateText": {
+    "message": "zum Navigieren",
+    "description": "The explanatory text of the action for the Arrow up and Arrow down key"
+  },
+  "theme.SearchModal.footer.navigateUpKeyAriaLabel": {
+    "message": "Pfeil nach oben",
+    "description": "The ARIA label for the Arrow up key button that makes the navigation"
+  },
+  "theme.SearchModal.footer.navigateDownKeyAriaLabel": {
+    "message": "Pfeil nach unten",
+    "description": "The ARIA label for the Arrow down key button that makes the navigation"
+  },
+  "theme.SearchModal.footer.closeText": {
+    "message": "zum Schließen",
+    "description": "The explanatory text of the action for Escape key"
+  },
+  "theme.SearchModal.footer.closeKeyAriaLabel": {
+    "message": "Escape-Taste",
+    "description": "The ARIA label for the Escape key button that close the modal"
+  },
+  "theme.SearchModal.footer.searchByText": {
+    "message": "Suche bereitgestellt von",
+    "description": "The text explain that the search is making by Algolia"
+  },
+  "theme.SearchModal.noResultsScreen.noResultsText": {
+    "message": "Keine Ergebnisse für",
+    "description": "The text explains that there are no results for the following search"
+  },
+  "theme.SearchModal.noResultsScreen.suggestedQueryText": {
+    "message": "Probiere es mit",
+    "description": "The text for the suggested query when no results are found for the following search"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsText": {
+    "message": "Diese Anfrage sollte Ergebnisse liefern?",
+    "description": "The text for the question where the user thinks there are missing results"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsLinkText": {
+    "message": "Lass es uns wissen.",
+    "description": "The text for the link to report missing results"
+  },
+  "theme.SearchModal.placeholder": {
+    "message": "Odysee Hilfe durchsuchen",
+    "description": "The placeholder of the input of the DocSearch pop-up modal"
   }
 }

--- a/i18n/de/docusaurus-theme-classic/footer.json
+++ b/i18n/de/docusaurus-theme-classic/footer.json
@@ -78,5 +78,9 @@
   "link.item.label.Instagram": {
     "message": "Instagram",
     "description": "The label of footer link with label=Instagram linking to https://www.instagram.com/odyseeforever/"
+  },
+  "link.item.label.help@odysee.com": {
+    "message": "help@odysee.com",
+    "description": "The label of footer link with label=help@odysee.com linking to mailto:help@odysee.com"
   }
 }

--- a/i18n/de/docusaurus-theme-classic/navbar.json
+++ b/i18n/de/docusaurus-theme-classic/navbar.json
@@ -10,5 +10,9 @@
   "item.label.Odysee": {
     "message": "Odysee",
     "description": "Navbar item with label Odysee"
+  },
+  "logo.alt": {
+    "message": "Odysee Logo",
+    "description": "The alt text of navbar logo"
   }
 }

--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -2,5 +2,403 @@
   "theme.common.editThisPage": {
     "message": "Suggest a change",
     "description": "The link label to edit the current page"
+  },
+  "theme.ErrorPageContent.title": {
+    "message": "This page crashed.",
+    "description": "The title of the fallback page when the page crashed"
+  },
+  "theme.NotFound.title": {
+    "message": "Page Not Found",
+    "description": "The title of the 404 page"
+  },
+  "theme.NotFound.p1": {
+    "message": "We could not find what you were looking for.",
+    "description": "The first paragraph of the 404 page"
+  },
+  "theme.NotFound.p2": {
+    "message": "Please contact the owner of the site that linked you to the original URL and let them know their link is broken.",
+    "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.admonition.note": {
+    "message": "note",
+    "description": "The default label used for the Note admonition (:::note)"
+  },
+  "theme.admonition.tip": {
+    "message": "tip",
+    "description": "The default label used for the Tip admonition (:::tip)"
+  },
+  "theme.admonition.danger": {
+    "message": "danger",
+    "description": "The default label used for the Danger admonition (:::danger)"
+  },
+  "theme.admonition.info": {
+    "message": "info",
+    "description": "The default label used for the Info admonition (:::info)"
+  },
+  "theme.admonition.caution": {
+    "message": "caution",
+    "description": "The default label used for the Caution admonition (:::caution)"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "Scroll back to top",
+    "description": "The ARIA label for the back to top button"
+  },
+  "theme.blog.archive.title": {
+    "message": "Archive",
+    "description": "The page & hero title of the blog archive page"
+  },
+  "theme.blog.archive.description": {
+    "message": "Archive",
+    "description": "The page & hero description of the blog archive page"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "Blog list page navigation",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "Newer Entries",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "Older Entries",
+    "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "Blog post page navigation",
+    "description": "The ARIA label for the blog posts pagination"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "Newer Post",
+    "description": "The blog post button label to navigate to the newer/previous post"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "Older Post",
+    "description": "The blog post button label to navigate to the older/next post"
+  },
+  "theme.blog.post.plurals": {
+    "message": "One post|{count} posts",
+    "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "{nPosts} tagged with \"{tagName}\"",
+    "description": "The title of the page for a blog tag"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "View All Tags",
+    "description": "The label of the link targeting the tag list page"
+  },
+  "theme.colorToggle.ariaLabel": {
+    "message": "Switch between dark and light mode (currently {mode})",
+    "description": "The ARIA label for the navbar color mode toggle"
+  },
+  "theme.colorToggle.ariaLabel.mode.dark": {
+    "message": "dark mode",
+    "description": "The name for the dark color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.light": {
+    "message": "light mode",
+    "description": "The name for the light color mode"
+  },
+  "theme.docs.breadcrumbs.navAriaLabel": {
+    "message": "Breadcrumbs",
+    "description": "The ARIA label for the breadcrumbs"
+  },
+  "theme.docs.DocCard.categoryDescription": {
+    "message": "{count} items",
+    "description": "The default description for a category card in the generated index about how many items this category includes"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "Docs pages",
+    "description": "The ARIA label for the docs pagination"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "Previous",
+    "description": "The label used to navigate to the previous doc"
+  },
+  "theme.docs.paginator.next": {
+    "message": "Next",
+    "description": "The label used to navigate to the next doc"
+  },
+  "theme.docs.versionBadge.label": {
+    "message": "Version: {versionLabel}"
+  },
+  "theme.docs.tagDocListPageTitle.nDocsTagged": {
+    "message": "One doc tagged|{count} docs tagged",
+    "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.tagDocListPageTitle": {
+    "message": "{nDocsTagged} with \"{tagName}\"",
+    "description": "The title of the page for a docs tag"
+  },
+  "theme.docs.versions.unreleasedVersionLabel": {
+    "message": "This is unreleased documentation for {siteTitle} {versionLabel} version.",
+    "description": "The label used to tell the user that he's browsing an unreleased doc version"
+  },
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "This is documentation for {siteTitle} {versionLabel}, which is no longer actively maintained.",
+    "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "For up-to-date documentation, see the {latestVersionLink} ({versionLabel}).",
+    "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.latestVersionLinkLabel": {
+    "message": "latest version",
+    "description": "The label used for the latest version suggestion link label"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "Direct link to {heading}",
+    "description": "Title for link to heading"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": " on {date}",
+    "description": "The words used to describe on which date a page has been last updated"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": " by {user}",
+    "description": "The words used to describe by who the page has been last updated"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "Last updated{atDate}{byUser}",
+    "description": "The sentence used to display when a page has been last updated, and by who"
+  },
+  "theme.navbar.mobileVersionsDropdown.label": {
+    "message": "Versions",
+    "description": "The label for the navbar versions dropdown on mobile view"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "Tags:",
+    "description": "The label alongside a tag list"
+  },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "Close",
+    "description": "The ARIA label for close button of announcement bar"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "Blog recent posts navigation",
+    "description": "The ARIA label for recent posts in the blog sidebar"
+  },
+  "theme.CodeBlock.copied": {
+    "message": "Copied",
+    "description": "The copied button label on code blocks"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "Copy code to clipboard",
+    "description": "The ARIA label for copy code blocks button"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "Copy",
+    "description": "The copy button label on code blocks"
+  },
+  "theme.CodeBlock.wordWrapToggle": {
+    "message": "Toggle word wrap",
+    "description": "The title attribute for toggle word wrapping button of code block lines"
+  },
+  "theme.DocSidebarItem.toggleCollapsedCategoryAriaLabel": {
+    "message": "Toggle the collapsible sidebar category '{label}'",
+    "description": "The ARIA label to toggle the collapsible sidebar category"
+  },
+  "theme.NavBar.navAriaLabel": {
+    "message": "Main",
+    "description": "The ARIA label for the main navigation"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "On this page",
+    "description": "The label used by the button on the collapsible TOC component"
+  },
+  "theme.blog.post.readMore": {
+    "message": "Read More",
+    "description": "The label used in blog post item excerpts to link to full blog posts"
+  },
+  "theme.blog.post.readMoreLabel": {
+    "message": "Read more about {title}",
+    "description": "The ARIA label for the link to full blog posts from excerpts"
+  },
+  "theme.navbar.mobileLanguageDropdown.label": {
+    "message": "Languages",
+    "description": "The label for the mobile language switcher dropdown"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "One min read|{readingTime} min read",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.breadcrumbs.home": {
+    "message": "Home page",
+    "description": "The ARIA label for the home page in the breadcrumbs"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "Collapse sidebar",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "Collapse sidebar",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.navAriaLabel": {
+    "message": "Docs sidebar",
+    "description": "The ARIA label for the sidebar navigation"
+  },
+  "theme.docs.sidebar.closeSidebarButtonAriaLabel": {
+    "message": "Close navigation bar",
+    "description": "The ARIA label for close button of mobile sidebar"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← Back to main menu",
+    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+  },
+  "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
+    "message": "Toggle navigation bar",
+    "description": "The ARIA label for hamburger menu button of mobile navigation"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "Expand sidebar",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "Expand sidebar",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.SearchBar.seeAll": {
+    "message": "See all {count} results"
+  },
+  "theme.SearchPage.documentsFound.plurals": {
+    "message": "One document found|{count} documents found",
+    "description": "Pluralized label for \"{count} documents found\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.SearchPage.existingResultsTitle": {
+    "message": "Search results for \"{query}\"",
+    "description": "The search page title for non-empty query"
+  },
+  "theme.SearchPage.emptyResultsTitle": {
+    "message": "Search the documentation",
+    "description": "The search page title for empty query"
+  },
+  "theme.SearchPage.inputPlaceholder": {
+    "message": "Type your search here",
+    "description": "The placeholder for search page input"
+  },
+  "theme.SearchPage.inputLabel": {
+    "message": "Search",
+    "description": "The ARIA label for search page input"
+  },
+  "theme.SearchPage.typesenseLabel": {
+    "message": "Search by Typesense",
+    "description": "The ARIA label for Typesense mention"
+  },
+  "theme.SearchPage.noResultsText": {
+    "message": "No results were found",
+    "description": "The paragraph for empty search result"
+  },
+  "theme.SearchPage.fetchingNewResults": {
+    "message": "Fetching new results...",
+    "description": "The paragraph for fetching new search results"
+  },
+  "theme.SearchBar.label": {
+    "message": "Search",
+    "description": "The ARIA label and placeholder for search button"
+  },
+  "theme.SearchModal.searchBox.resetButtonTitle": {
+    "message": "Clear the query",
+    "description": "The label and ARIA label for search box reset button"
+  },
+  "theme.SearchModal.searchBox.cancelButtonText": {
+    "message": "Cancel",
+    "description": "The label and ARIA label for search box cancel button"
+  },
+  "theme.SearchModal.startScreen.recentSearchesTitle": {
+    "message": "Recent",
+    "description": "The title for recent searches"
+  },
+  "theme.SearchModal.startScreen.noRecentSearchesText": {
+    "message": "No recent searches",
+    "description": "The text when no recent searches"
+  },
+  "theme.SearchModal.startScreen.saveRecentSearchButtonTitle": {
+    "message": "Save this search",
+    "description": "The label for save recent search button"
+  },
+  "theme.SearchModal.startScreen.removeRecentSearchButtonTitle": {
+    "message": "Remove this search from history",
+    "description": "The label for remove recent search button"
+  },
+  "theme.SearchModal.startScreen.favoriteSearchesTitle": {
+    "message": "Favorite",
+    "description": "The title for favorite searches"
+  },
+  "theme.SearchModal.startScreen.removeFavoriteSearchButtonTitle": {
+    "message": "Remove this search from favorites",
+    "description": "The label for remove favorite search button"
+  },
+  "theme.SearchModal.errorScreen.titleText": {
+    "message": "Unable to fetch results",
+    "description": "The title for error screen of search modal"
+  },
+  "theme.SearchModal.errorScreen.helpText": {
+    "message": "You might want to check your network connection.",
+    "description": "The help text for error screen of search modal"
+  },
+  "theme.SearchModal.footer.selectText": {
+    "message": "to select",
+    "description": "The explanatory text of the action for the enter key"
+  },
+  "theme.SearchModal.footer.selectKeyAriaLabel": {
+    "message": "Enter key",
+    "description": "The ARIA label for the Enter key button that makes the selection"
+  },
+  "theme.SearchModal.footer.navigateText": {
+    "message": "to navigate",
+    "description": "The explanatory text of the action for the Arrow up and Arrow down key"
+  },
+  "theme.SearchModal.footer.navigateUpKeyAriaLabel": {
+    "message": "Arrow up",
+    "description": "The ARIA label for the Arrow up key button that makes the navigation"
+  },
+  "theme.SearchModal.footer.navigateDownKeyAriaLabel": {
+    "message": "Arrow down",
+    "description": "The ARIA label for the Arrow down key button that makes the navigation"
+  },
+  "theme.SearchModal.footer.closeText": {
+    "message": "to close",
+    "description": "The explanatory text of the action for Escape key"
+  },
+  "theme.SearchModal.footer.closeKeyAriaLabel": {
+    "message": "Escape key",
+    "description": "The ARIA label for the Escape key button that close the modal"
+  },
+  "theme.SearchModal.footer.searchByText": {
+    "message": "Search by",
+    "description": "The text explain that the search is making by Algolia"
+  },
+  "theme.SearchModal.noResultsScreen.noResultsText": {
+    "message": "No results for",
+    "description": "The text explains that there are no results for the following search"
+  },
+  "theme.SearchModal.noResultsScreen.suggestedQueryText": {
+    "message": "Try searching for",
+    "description": "The text for the suggested query when no results are found for the following search"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsText": {
+    "message": "Believe this query should return results?",
+    "description": "The text for the question where the user thinks there are missing results"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsLinkText": {
+    "message": "Let us know.",
+    "description": "The text for the link to report missing results"
+  },
+  "theme.SearchModal.placeholder": {
+    "message": "Search docs",
+    "description": "The placeholder of the input of the DocSearch pop-up modal"
+  },
+  "theme.ErrorPageContent.tryAgain": {
+    "message": "Try again",
+    "description": "The label of the button to try again rendering when the React error boundary captures an error"
+  },
+  "theme.common.skipToMainContent": {
+    "message": "Skip to main content",
+    "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "theme.tags.tagsPageTitle": {
+    "message": "Tags",
+    "description": "The title of the tag list page"
   }
 }

--- a/i18n/es/code.json
+++ b/i18n/es/code.json
@@ -5,7 +5,7 @@
   },
   "theme.ErrorPageContent.tryAgain": {
     "message": "Try again",
-    "description": "The label of the button to try again when the page crashed"
+    "description": "The label of the button to try again rendering when the React error boundary captures an error"
   },
   "theme.NotFound.title": {
     "message": "Página No Encontrada",
@@ -299,5 +299,129 @@
   "theme.tags.tagsPageTitle": {
     "message": "Etiquetas",
     "description": "The title of the tag list page"
+  },
+  "theme.NavBar.navAriaLabel": {
+    "message": "Main",
+    "description": "The ARIA label for the main navigation"
+  },
+  "theme.docs.sidebar.navAriaLabel": {
+    "message": "Docs sidebar",
+    "description": "The ARIA label for the sidebar navigation"
+  },
+  "theme.docs.sidebar.closeSidebarButtonAriaLabel": {
+    "message": "Close navigation bar",
+    "description": "The ARIA label for close button of mobile sidebar"
+  },
+  "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
+    "message": "Toggle navigation bar",
+    "description": "The ARIA label for hamburger menu button of mobile navigation"
+  },
+  "theme.SearchPage.inputPlaceholder": {
+    "message": "Type your search here",
+    "description": "The placeholder for search page input"
+  },
+  "theme.SearchPage.inputLabel": {
+    "message": "Search",
+    "description": "The ARIA label for search page input"
+  },
+  "theme.SearchPage.typesenseLabel": {
+    "message": "Search by Typesense",
+    "description": "The ARIA label for Typesense mention"
+  },
+  "theme.SearchPage.fetchingNewResults": {
+    "message": "Fetching new results...",
+    "description": "The paragraph for fetching new search results"
+  },
+  "theme.SearchModal.searchBox.resetButtonTitle": {
+    "message": "Clear the query",
+    "description": "The label and ARIA label for search box reset button"
+  },
+  "theme.SearchModal.searchBox.cancelButtonText": {
+    "message": "Cancel",
+    "description": "The label and ARIA label for search box cancel button"
+  },
+  "theme.SearchModal.startScreen.recentSearchesTitle": {
+    "message": "Recent",
+    "description": "The title for recent searches"
+  },
+  "theme.SearchModal.startScreen.noRecentSearchesText": {
+    "message": "No recent searches",
+    "description": "The text when no recent searches"
+  },
+  "theme.SearchModal.startScreen.saveRecentSearchButtonTitle": {
+    "message": "Save this search",
+    "description": "The label for save recent search button"
+  },
+  "theme.SearchModal.startScreen.removeRecentSearchButtonTitle": {
+    "message": "Remove this search from history",
+    "description": "The label for remove recent search button"
+  },
+  "theme.SearchModal.startScreen.favoriteSearchesTitle": {
+    "message": "Favorite",
+    "description": "The title for favorite searches"
+  },
+  "theme.SearchModal.startScreen.removeFavoriteSearchButtonTitle": {
+    "message": "Remove this search from favorites",
+    "description": "The label for remove favorite search button"
+  },
+  "theme.SearchModal.errorScreen.titleText": {
+    "message": "Unable to fetch results",
+    "description": "The title for error screen of search modal"
+  },
+  "theme.SearchModal.errorScreen.helpText": {
+    "message": "You might want to check your network connection.",
+    "description": "The help text for error screen of search modal"
+  },
+  "theme.SearchModal.footer.selectText": {
+    "message": "to select",
+    "description": "The explanatory text of the action for the enter key"
+  },
+  "theme.SearchModal.footer.selectKeyAriaLabel": {
+    "message": "Enter key",
+    "description": "The ARIA label for the Enter key button that makes the selection"
+  },
+  "theme.SearchModal.footer.navigateText": {
+    "message": "to navigate",
+    "description": "The explanatory text of the action for the Arrow up and Arrow down key"
+  },
+  "theme.SearchModal.footer.navigateUpKeyAriaLabel": {
+    "message": "Arrow up",
+    "description": "The ARIA label for the Arrow up key button that makes the navigation"
+  },
+  "theme.SearchModal.footer.navigateDownKeyAriaLabel": {
+    "message": "Arrow down",
+    "description": "The ARIA label for the Arrow down key button that makes the navigation"
+  },
+  "theme.SearchModal.footer.closeText": {
+    "message": "to close",
+    "description": "The explanatory text of the action for Escape key"
+  },
+  "theme.SearchModal.footer.closeKeyAriaLabel": {
+    "message": "Escape key",
+    "description": "The ARIA label for the Escape key button that close the modal"
+  },
+  "theme.SearchModal.footer.searchByText": {
+    "message": "Search by",
+    "description": "The text explain that the search is making by Algolia"
+  },
+  "theme.SearchModal.noResultsScreen.noResultsText": {
+    "message": "No results for",
+    "description": "The text explains that there are no results for the following search"
+  },
+  "theme.SearchModal.noResultsScreen.suggestedQueryText": {
+    "message": "Try searching for",
+    "description": "The text for the suggested query when no results are found for the following search"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsText": {
+    "message": "Believe this query should return results?",
+    "description": "The text for the question where the user thinks there are missing results"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsLinkText": {
+    "message": "Let us know.",
+    "description": "The text for the link to report missing results"
+  },
+  "theme.SearchModal.placeholder": {
+    "message": "Search docs",
+    "description": "The placeholder of the input of the DocSearch pop-up modal"
   }
 }

--- a/i18n/es/docusaurus-plugin-content-docs/current.json
+++ b/i18n/es/docusaurus-plugin-content-docs/current.json
@@ -93,7 +93,7 @@
   },
   "sidebar.helphub.category.Wallet & Transactions": {
     "message": "Monedero y transacciones",
-    "description": "The label for category Wallet in sidebar helphub"
+    "description": "The label for category Wallet & Transactions in sidebar helphub"
   },
   "sidebar.helphub.category.Playlists": {
     "message": "Listas de reproducción",
@@ -105,11 +105,11 @@
   },
   "sidebar.helphub.category.Memberships": {
     "message": "Membresías",
-    "description": "The label for category Membresías in sidebar helphub"
+    "description": "The label for category Memberships in sidebar helphub"
   },
   "sidebar.helphub.category.Creator Portal": {
     "message": "Portal del creador",
-    "description": "The label for category Portal del creador in sidebar helphub"
+    "description": "The label for category Creator Portal in sidebar helphub"
   },
   "sidebar.helphub.category.Donor Portal": {
     "message": "Portal de donantes",

--- a/i18n/es/docusaurus-theme-classic/footer.json
+++ b/i18n/es/docusaurus-theme-classic/footer.json
@@ -21,7 +21,7 @@
   },
   "link.item.label.Twitter": {
     "message": "Twitter",
-    "description": "The label of footer link with label=Twitter linking to https://twitter.com/OdyseeEs"
+    "description": "The label of footer link with label=Twitter linking to https://twitter.com/odyseeteam"
   },
   "link.item.label.GitHub": {
     "message": "GitHub",
@@ -41,11 +41,11 @@
   },
   "link.item.label.Facebook": {
     "message": "Facebook",
-    "description": "The label of footer link with label=Facebook linking to https://www.facebook.com/OdyseeVideo/"
+    "description": "The label of footer link with label=Facebook linking to https://www.facebook.com/OdyseeForever/"
   },
   "link.item.label.TikTok": {
     "message": "TikTok",
-    "description": "The label of footer link with label=TikTok linking to https://www.tiktok.com/@odyseeteam"
+    "description": "The label of footer link with label=TikTok linking to https://www.tiktok.com/@odyseeforever"
   },
   "link.item.label.Privacy Policy": {
     "message": "Privacy Policy",
@@ -70,5 +70,13 @@
   "link.item.label.Timeline": {
     "message": "Timeline",
     "description": "The label of footer link with label=Timeline linking to /timeline"
+  },
+  "link.item.label.Instagram": {
+    "message": "Instagram",
+    "description": "The label of footer link with label=Instagram linking to https://www.instagram.com/odyseeforever/"
+  },
+  "link.item.label.help@odysee.com": {
+    "message": "help@odysee.com",
+    "description": "The label of footer link with label=help@odysee.com linking to mailto:help@odysee.com"
   }
 }

--- a/i18n/es/docusaurus-theme-classic/navbar.json
+++ b/i18n/es/docusaurus-theme-classic/navbar.json
@@ -10,5 +10,9 @@
   "item.label.Odysee": {
     "message": "Odysee",
     "description": "Navbar item with label Odysee"
+  },
+  "logo.alt": {
+    "message": "Odysee Logo",
+    "description": "The alt text of navbar logo"
   }
 }

--- a/i18n/fr/code.json
+++ b/i18n/fr/code.json
@@ -5,7 +5,7 @@
   },
   "theme.ErrorPageContent.tryAgain": {
     "message": "Réessayer",
-    "description": "The label of the button to try again when the page crashed"
+    "description": "The label of the button to try again rendering when the React error boundary captures an error"
   },
   "theme.NotFound.title": {
     "message": "Page introuvable",
@@ -299,5 +299,129 @@
   "theme.tags.tagsPageTitle": {
     "message": "Tags",
     "description": "The title of the tag list page"
+  },
+  "theme.NavBar.navAriaLabel": {
+    "message": "Main",
+    "description": "The ARIA label for the main navigation"
+  },
+  "theme.docs.sidebar.navAriaLabel": {
+    "message": "Docs sidebar",
+    "description": "The ARIA label for the sidebar navigation"
+  },
+  "theme.docs.sidebar.closeSidebarButtonAriaLabel": {
+    "message": "Fermer la barre de navigation",
+    "description": "The ARIA label for close button of mobile sidebar"
+  },
+  "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
+    "message": "Ouvrir/fermer la barre de navigation",
+    "description": "The ARIA label for hamburger menu button of mobile navigation"
+  },
+  "theme.SearchModal.searchBox.resetButtonTitle": {
+    "message": "Clear the query",
+    "description": "The label and ARIA label for search box reset button"
+  },
+  "theme.SearchModal.searchBox.cancelButtonText": {
+    "message": "Cancel",
+    "description": "The label and ARIA label for search box cancel button"
+  },
+  "theme.SearchModal.startScreen.recentSearchesTitle": {
+    "message": "Recent",
+    "description": "The title for recent searches"
+  },
+  "theme.SearchModal.startScreen.noRecentSearchesText": {
+    "message": "No recent searches",
+    "description": "The text when no recent searches"
+  },
+  "theme.SearchModal.startScreen.saveRecentSearchButtonTitle": {
+    "message": "Save this search",
+    "description": "The label for save recent search button"
+  },
+  "theme.SearchModal.startScreen.removeRecentSearchButtonTitle": {
+    "message": "Remove this search from history",
+    "description": "The label for remove recent search button"
+  },
+  "theme.SearchModal.startScreen.favoriteSearchesTitle": {
+    "message": "Favorite",
+    "description": "The title for favorite searches"
+  },
+  "theme.SearchModal.startScreen.removeFavoriteSearchButtonTitle": {
+    "message": "Remove this search from favorites",
+    "description": "The label for remove favorite search button"
+  },
+  "theme.SearchModal.errorScreen.titleText": {
+    "message": "Unable to fetch results",
+    "description": "The title for error screen of search modal"
+  },
+  "theme.SearchModal.errorScreen.helpText": {
+    "message": "You might want to check your network connection.",
+    "description": "The help text for error screen of search modal"
+  },
+  "theme.SearchModal.footer.selectText": {
+    "message": "to select",
+    "description": "The explanatory text of the action for the enter key"
+  },
+  "theme.SearchModal.footer.selectKeyAriaLabel": {
+    "message": "Enter key",
+    "description": "The ARIA label for the Enter key button that makes the selection"
+  },
+  "theme.SearchModal.footer.navigateText": {
+    "message": "to navigate",
+    "description": "The explanatory text of the action for the Arrow up and Arrow down key"
+  },
+  "theme.SearchModal.footer.navigateUpKeyAriaLabel": {
+    "message": "Arrow up",
+    "description": "The ARIA label for the Arrow up key button that makes the navigation"
+  },
+  "theme.SearchModal.footer.navigateDownKeyAriaLabel": {
+    "message": "Arrow down",
+    "description": "The ARIA label for the Arrow down key button that makes the navigation"
+  },
+  "theme.SearchModal.footer.closeText": {
+    "message": "to close",
+    "description": "The explanatory text of the action for Escape key"
+  },
+  "theme.SearchModal.footer.closeKeyAriaLabel": {
+    "message": "Escape key",
+    "description": "The ARIA label for the Escape key button that close the modal"
+  },
+  "theme.SearchModal.footer.searchByText": {
+    "message": "Search by",
+    "description": "The text explain that the search is making by Algolia"
+  },
+  "theme.SearchModal.noResultsScreen.noResultsText": {
+    "message": "No results for",
+    "description": "The text explains that there are no results for the following search"
+  },
+  "theme.SearchModal.noResultsScreen.suggestedQueryText": {
+    "message": "Try searching for",
+    "description": "The text for the suggested query when no results are found for the following search"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsText": {
+    "message": "Believe this query should return results?",
+    "description": "The text for the question where the user thinks there are missing results"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsLinkText": {
+    "message": "Let us know.",
+    "description": "The text for the link to report missing results"
+  },
+  "theme.SearchModal.placeholder": {
+    "message": "Search docs",
+    "description": "The placeholder of the input of the DocSearch pop-up modal"
+  },
+  "theme.SearchPage.inputPlaceholder": {
+    "message": "Type your search here",
+    "description": "The placeholder for search page input"
+  },
+  "theme.SearchPage.inputLabel": {
+    "message": "Search",
+    "description": "The ARIA label for search page input"
+  },
+  "theme.SearchPage.typesenseLabel": {
+    "message": "Search by Typesense",
+    "description": "The ARIA label for Typesense mention"
+  },
+  "theme.SearchPage.fetchingNewResults": {
+    "message": "Fetching new results...",
+    "description": "The paragraph for fetching new search results"
   }
 }

--- a/i18n/fr/docusaurus-theme-classic/footer.json
+++ b/i18n/fr/docusaurus-theme-classic/footer.json
@@ -74,5 +74,9 @@
   "link.item.label.Instagram": {
     "message": "Instagram",
     "description": "The label of footer link with label=Instagram linking to https://www.instagram.com/odyseeforever/"
+  },
+  "link.item.label.help@odysee.com": {
+    "message": "help@odysee.com",
+    "description": "The label of footer link with label=help@odysee.com linking to mailto:help@odysee.com"
   }
 }

--- a/i18n/fr/docusaurus-theme-classic/navbar.json
+++ b/i18n/fr/docusaurus-theme-classic/navbar.json
@@ -10,5 +10,9 @@
   "item.label.Odysee": {
     "message": "Odysee",
     "description": "Navbar item with label Odysee"
+  },
+  "logo.alt": {
+    "message": "Odysee Logo",
+    "description": "The alt text of navbar logo"
   }
 }

--- a/i18n/pt/code.json
+++ b/i18n/pt/code.json
@@ -5,7 +5,7 @@
   },
   "theme.ErrorPageContent.tryAgain": {
     "message": "Try again",
-    "description": "The label of the button to try again when the page crashed"
+    "description": "The label of the button to try again rendering when the React error boundary captures an error"
   },
   "theme.NotFound.title": {
     "message": "Página não encontrada",
@@ -299,5 +299,129 @@
   "theme.tags.tagsPageTitle": {
     "message": "Marcadores",
     "description": "The title of the tag list page"
+  },
+  "theme.NavBar.navAriaLabel": {
+    "message": "Main",
+    "description": "The ARIA label for the main navigation"
+  },
+  "theme.docs.sidebar.navAriaLabel": {
+    "message": "Docs sidebar",
+    "description": "The ARIA label for the sidebar navigation"
+  },
+  "theme.docs.sidebar.closeSidebarButtonAriaLabel": {
+    "message": "Close navigation bar",
+    "description": "The ARIA label for close button of mobile sidebar"
+  },
+  "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
+    "message": "Toggle navigation bar",
+    "description": "The ARIA label for hamburger menu button of mobile navigation"
+  },
+  "theme.SearchPage.inputPlaceholder": {
+    "message": "Type your search here",
+    "description": "The placeholder for search page input"
+  },
+  "theme.SearchPage.inputLabel": {
+    "message": "Search",
+    "description": "The ARIA label for search page input"
+  },
+  "theme.SearchPage.typesenseLabel": {
+    "message": "Search by Typesense",
+    "description": "The ARIA label for Typesense mention"
+  },
+  "theme.SearchPage.fetchingNewResults": {
+    "message": "Fetching new results...",
+    "description": "The paragraph for fetching new search results"
+  },
+  "theme.SearchModal.searchBox.resetButtonTitle": {
+    "message": "Clear the query",
+    "description": "The label and ARIA label for search box reset button"
+  },
+  "theme.SearchModal.searchBox.cancelButtonText": {
+    "message": "Cancel",
+    "description": "The label and ARIA label for search box cancel button"
+  },
+  "theme.SearchModal.startScreen.recentSearchesTitle": {
+    "message": "Recent",
+    "description": "The title for recent searches"
+  },
+  "theme.SearchModal.startScreen.noRecentSearchesText": {
+    "message": "No recent searches",
+    "description": "The text when no recent searches"
+  },
+  "theme.SearchModal.startScreen.saveRecentSearchButtonTitle": {
+    "message": "Save this search",
+    "description": "The label for save recent search button"
+  },
+  "theme.SearchModal.startScreen.removeRecentSearchButtonTitle": {
+    "message": "Remove this search from history",
+    "description": "The label for remove recent search button"
+  },
+  "theme.SearchModal.startScreen.favoriteSearchesTitle": {
+    "message": "Favorite",
+    "description": "The title for favorite searches"
+  },
+  "theme.SearchModal.startScreen.removeFavoriteSearchButtonTitle": {
+    "message": "Remove this search from favorites",
+    "description": "The label for remove favorite search button"
+  },
+  "theme.SearchModal.errorScreen.titleText": {
+    "message": "Unable to fetch results",
+    "description": "The title for error screen of search modal"
+  },
+  "theme.SearchModal.errorScreen.helpText": {
+    "message": "You might want to check your network connection.",
+    "description": "The help text for error screen of search modal"
+  },
+  "theme.SearchModal.footer.selectText": {
+    "message": "to select",
+    "description": "The explanatory text of the action for the enter key"
+  },
+  "theme.SearchModal.footer.selectKeyAriaLabel": {
+    "message": "Enter key",
+    "description": "The ARIA label for the Enter key button that makes the selection"
+  },
+  "theme.SearchModal.footer.navigateText": {
+    "message": "to navigate",
+    "description": "The explanatory text of the action for the Arrow up and Arrow down key"
+  },
+  "theme.SearchModal.footer.navigateUpKeyAriaLabel": {
+    "message": "Arrow up",
+    "description": "The ARIA label for the Arrow up key button that makes the navigation"
+  },
+  "theme.SearchModal.footer.navigateDownKeyAriaLabel": {
+    "message": "Arrow down",
+    "description": "The ARIA label for the Arrow down key button that makes the navigation"
+  },
+  "theme.SearchModal.footer.closeText": {
+    "message": "to close",
+    "description": "The explanatory text of the action for Escape key"
+  },
+  "theme.SearchModal.footer.closeKeyAriaLabel": {
+    "message": "Escape key",
+    "description": "The ARIA label for the Escape key button that close the modal"
+  },
+  "theme.SearchModal.footer.searchByText": {
+    "message": "Search by",
+    "description": "The text explain that the search is making by Algolia"
+  },
+  "theme.SearchModal.noResultsScreen.noResultsText": {
+    "message": "No results for",
+    "description": "The text explains that there are no results for the following search"
+  },
+  "theme.SearchModal.noResultsScreen.suggestedQueryText": {
+    "message": "Try searching for",
+    "description": "The text for the suggested query when no results are found for the following search"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsText": {
+    "message": "Believe this query should return results?",
+    "description": "The text for the question where the user thinks there are missing results"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsLinkText": {
+    "message": "Let us know.",
+    "description": "The text for the link to report missing results"
+  },
+  "theme.SearchModal.placeholder": {
+    "message": "Search docs",
+    "description": "The placeholder of the input of the DocSearch pop-up modal"
   }
 }

--- a/i18n/pt/docusaurus-theme-classic/footer.json
+++ b/i18n/pt/docusaurus-theme-classic/footer.json
@@ -74,5 +74,9 @@
   "link.item.label.Instagram": {
     "message": "Instagram",
     "description": "The label of footer link with label=Instagram linking to https://www.instagram.com/odyseeforever/"
+  },
+  "link.item.label.help@odysee.com": {
+    "message": "help@odysee.com",
+    "description": "The label of footer link with label=help@odysee.com linking to mailto:help@odysee.com"
   }
 }

--- a/i18n/pt/docusaurus-theme-classic/navbar.json
+++ b/i18n/pt/docusaurus-theme-classic/navbar.json
@@ -10,5 +10,9 @@
   "item.label.Odysee": {
     "message": "Odysee",
     "description": "Navbar item with label Odysee"
+  },
+  "logo.alt": {
+    "message": "Odysee Logo",
+    "description": "The alt text of navbar logo"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "odysee-docs",
       "version": "0.0.0",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/preset-classic": "2.1.0",
+        "@docusaurus/core": "^2.4.1",
+        "@docusaurus/preset-classic": "^2.4.1",
         "@easyops-cn/docusaurus-search-local": "^0.32.0",
         "@fortawesome/fontawesome-svg-core": "^6.2.0",
         "@fortawesome/free-brands-svg-icons": "^6.2.0",
@@ -17,6 +17,7 @@
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
+        "docusaurus-theme-search-typesense": "^0.11.0",
         "prism-react-renderer": "^1.3.5",
         "react": "^17.0.2",
         "react-children-utilities": "^2.8.0",
@@ -24,106 +25,106 @@
         "webpack-font-preload-plugin": "^1.5.0"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "2.1.0"
+        "@docusaurus/module-type-aliases": "^2.4.1"
       },
       "engines": {
         "node": ">=16.14"
       }
     },
     "node_modules/@algolia/autocomplete-core": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.1.tgz",
-      "integrity": "sha512-eiZw+fxMzNQn01S8dA/hcCpoWCOCwcIIEUtHHdzN5TGB3IpzLbuhqFeTfh2OUhhgkE8Uo17+wH+QJ/wYyQmmzg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.8.2.tgz",
+      "integrity": "sha512-mTeshsyFhAqw/ebqNsQpMtbnjr+qVOSKXArEj4K0d7sqc8It1XD0gkASwecm9mF/jlOQ4Z9RNg1HbdA8JPdRwQ==",
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.7.1"
+        "@algolia/autocomplete-shared": "1.8.2"
       }
     },
     "node_modules/@algolia/autocomplete-preset-algolia": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.1.tgz",
-      "integrity": "sha512-pJwmIxeJCymU1M6cGujnaIYcY3QPOVYZOXhFkWVM7IxKzy272BwCvMFMyc5NpG/QmiObBxjo7myd060OeTNJXg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.8.2.tgz",
+      "integrity": "sha512-J0oTx4me6ZM9kIKPuL3lyU3aB8DEvpVvR6xWmHVROx5rOYJGQcZsdG4ozxwcOyiiu3qxMkIbzntnV1S1VWD8yA==",
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.7.1"
+        "@algolia/autocomplete-shared": "1.8.2"
       },
       "peerDependencies": {
-        "@algolia/client-search": "^4.9.1",
-        "algoliasearch": "^4.9.1"
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
       }
     },
     "node_modules/@algolia/autocomplete-shared": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.1.tgz",
-      "integrity": "sha512-eTmGVqY3GeyBTT8IWiB2K5EuURAqhnumfktAEoHxfDY2o7vg2rSnO16ZtIG0fMgt3py28Vwgq42/bVEuaQV7pg=="
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.8.2.tgz",
+      "integrity": "sha512-b6Z/X4MczChMcfhk6kfRmBzPgjoPzuS9KGR4AFsiLulLNRAAqhP+xZTKtMnZGhLuc61I20d5WqlId02AZvcO6g=="
     },
     "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.2.tgz",
-      "integrity": "sha512-FRweBkK/ywO+GKYfAWbrepewQsPTIEirhi1BdykX9mxvBPtGNKccYAxvGdDCumU1jL4r3cayio4psfzKMejBlA==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.17.0.tgz",
+      "integrity": "sha512-myRSRZDIMYB8uCkO+lb40YKiYHi0fjpWRtJpR/dgkaiBlSD0plRyB6lLOh1XIfmMcSeBOqDE7y9m8xZMrXYfyQ==",
       "dependencies": {
-        "@algolia/cache-common": "4.14.2"
+        "@algolia/cache-common": "4.17.0"
       }
     },
     "node_modules/@algolia/cache-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.2.tgz",
-      "integrity": "sha512-SbvAlG9VqNanCErr44q6lEKD2qoK4XtFNx9Qn8FK26ePCI8I9yU7pYB+eM/cZdS9SzQCRJBbHUumVr4bsQ4uxg=="
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.17.0.tgz",
+      "integrity": "sha512-g8mXzkrcUBIPZaulAuqE7xyHhLAYAcF2xSch7d9dABheybaU3U91LjBX6eJTEB7XVhEsgK4Smi27vWtAJRhIKQ=="
     },
     "node_modules/@algolia/cache-in-memory": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.2.tgz",
-      "integrity": "sha512-HrOukWoop9XB/VFojPv1R5SVXowgI56T9pmezd/djh2JnVN/vXswhXV51RKy4nCpqxyHt/aGFSq2qkDvj6KiuQ==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.17.0.tgz",
+      "integrity": "sha512-PT32ciC/xI8z919d0oknWVu3kMfTlhQn3MKxDln3pkn+yA7F7xrxSALysxquv+MhFfNAcrtQ/oVvQVBAQSHtdw==",
       "dependencies": {
-        "@algolia/cache-common": "4.14.2"
+        "@algolia/cache-common": "4.17.0"
       }
     },
     "node_modules/@algolia/client-account": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.2.tgz",
-      "integrity": "sha512-WHtriQqGyibbb/Rx71YY43T0cXqyelEU0lB2QMBRXvD2X0iyeGl4qMxocgEIcbHyK7uqE7hKgjT8aBrHqhgc1w==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.17.0.tgz",
+      "integrity": "sha512-sSEHx9GA6m7wrlsSMNBGfyzlIfDT2fkz2u7jqfCCd6JEEwmxt8emGmxAU/0qBfbhRSuGvzojoLJlr83BSZAKjA==",
       "dependencies": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/client-search": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/client-common": "4.17.0",
+        "@algolia/client-search": "4.17.0",
+        "@algolia/transporter": "4.17.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.2.tgz",
-      "integrity": "sha512-yBvBv2mw+HX5a+aeR0dkvUbFZsiC4FKSnfqk9rrfX+QrlNOKEhCG0tJzjiOggRW4EcNqRmaTULIYvIzQVL2KYQ==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.17.0.tgz",
+      "integrity": "sha512-84ooP8QA3mQ958hQ9wozk7hFUbAO+81CX1CjAuerxBqjKIInh1fOhXKTaku05O/GHBvcfExpPLIQuSuLYziBXQ==",
       "dependencies": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/client-search": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/client-common": "4.17.0",
+        "@algolia/client-search": "4.17.0",
+        "@algolia/requester-common": "4.17.0",
+        "@algolia/transporter": "4.17.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.2.tgz",
-      "integrity": "sha512-43o4fslNLcktgtDMVaT5XwlzsDPzlqvqesRi4MjQz2x4/Sxm7zYg5LRYFol1BIhG6EwxKvSUq8HcC/KxJu3J0Q==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.17.0.tgz",
+      "integrity": "sha512-jHMks0ZFicf8nRDn6ma8DNNsdwGgP/NKiAAL9z6rS7CymJ7L0+QqTJl3rYxRW7TmBhsUH40wqzmrG6aMIN/DrQ==",
       "dependencies": {
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/requester-common": "4.17.0",
+        "@algolia/transporter": "4.17.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.2.tgz",
-      "integrity": "sha512-ACCoLi0cL8CBZ1W/2juehSltrw2iqsQBnfiu/Rbl9W2yE6o2ZUb97+sqN/jBqYNQBS+o0ekTMKNkQjHHAcEXNw==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.17.0.tgz",
+      "integrity": "sha512-RMzN4dZLIta1YuwT7QC9o+OeGz2cU6eTOlGNE/6RcUBLOU3l9tkCOdln5dPE2jp8GZXPl2yk54b2nSs1+pAjqw==",
       "dependencies": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/client-common": "4.17.0",
+        "@algolia/requester-common": "4.17.0",
+        "@algolia/transporter": "4.17.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.2.tgz",
-      "integrity": "sha512-L5zScdOmcZ6NGiVbLKTvP02UbxZ0njd5Vq9nJAmPFtjffUSOGEp11BmD2oMJ5QvARgx2XbX4KzTTNS5ECYIMWw==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.17.0.tgz",
+      "integrity": "sha512-x4P2wKrrRIXszT8gb7eWsMHNNHAJs0wE7/uqbufm4tZenAp+hwU/hq5KVsY50v+PfwM0LcDwwn/1DroujsTFoA==",
       "dependencies": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/client-common": "4.17.0",
+        "@algolia/requester-common": "4.17.0",
+        "@algolia/transporter": "4.17.0"
       }
     },
     "node_modules/@algolia/events": {
@@ -132,47 +133,47 @@
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
     "node_modules/@algolia/logger-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.2.tgz",
-      "integrity": "sha512-/JGlYvdV++IcMHBnVFsqEisTiOeEr6cUJtpjz8zc0A9c31JrtLm318Njc72p14Pnkw3A/5lHHh+QxpJ6WFTmsA=="
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.17.0.tgz",
+      "integrity": "sha512-DGuoZqpTmIKJFDeyAJ7M8E/LOenIjWiOsg1XJ1OqAU/eofp49JfqXxbfgctlVZVmDABIyOz8LqEoJ6ZP4DTyvw=="
     },
     "node_modules/@algolia/logger-console": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.2.tgz",
-      "integrity": "sha512-8S2PlpdshbkwlLCSAB5f8c91xyc84VM9Ar9EdfE9UmX+NrKNYnWR1maXXVDQQoto07G1Ol/tYFnFVhUZq0xV/g==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.17.0.tgz",
+      "integrity": "sha512-zMPvugQV/gbXUvWBCzihw6m7oxIKp48w37QBIUu/XqQQfxhjoOE9xyfJr1KldUt5FrYOKZJVsJaEjTsu+bIgQg==",
       "dependencies": {
-        "@algolia/logger-common": "4.14.2"
+        "@algolia/logger-common": "4.17.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.2.tgz",
-      "integrity": "sha512-CEh//xYz/WfxHFh7pcMjQNWgpl4wFB85lUMRyVwaDPibNzQRVcV33YS+63fShFWc2+42YEipFGH2iPzlpszmDw==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.17.0.tgz",
+      "integrity": "sha512-aSOX/smauyTkP21Pf52pJ1O2LmNFJ5iHRIzEeTh0mwBeADO4GdG94cAWDILFA9rNblq/nK3EDh3+UyHHjplZ1A==",
       "dependencies": {
-        "@algolia/requester-common": "4.14.2"
+        "@algolia/requester-common": "4.17.0"
       }
     },
     "node_modules/@algolia/requester-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.2.tgz",
-      "integrity": "sha512-73YQsBOKa5fvVV3My7iZHu1sUqmjjfs9TteFWwPwDmnad7T0VTCopttcsM3OjLxZFtBnX61Xxl2T2gmG2O4ehg=="
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.17.0.tgz",
+      "integrity": "sha512-XJjmWFEUlHu0ijvcHBoixuXfEoiRUdyzQM6YwTuB8usJNIgShua8ouFlRWF8iCeag0vZZiUm4S2WCVBPkdxFgg=="
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.2.tgz",
-      "integrity": "sha512-oDbb02kd1o5GTEld4pETlPZLY0e+gOSWjWMJHWTgDXbv9rm/o2cF7japO6Vj1ENnrqWvLBmW1OzV9g6FUFhFXg==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.17.0.tgz",
+      "integrity": "sha512-bpb/wDA1aC6WxxM8v7TsFspB7yBN3nqCGs2H1OADolQR/hiAIjAxusbuMxVbRFOdaUvAIqioIIkWvZdpYNIn8w==",
       "dependencies": {
-        "@algolia/requester-common": "4.14.2"
+        "@algolia/requester-common": "4.17.0"
       }
     },
     "node_modules/@algolia/transporter": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.2.tgz",
-      "integrity": "sha512-t89dfQb2T9MFQHidjHcfhh6iGMNwvuKUvojAj+JsrHAGbuSy7yE4BylhLX6R0Q1xYRoC4Vvv+O5qIw/LdnQfsQ==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.17.0.tgz",
+      "integrity": "sha512-6xL6H6fe+Fi0AEP3ziSgC+G04RK37iRb4uUUqVAH9WPYFI8g+LYFq6iv5HS8Cbuc5TTut+Bwj6G+dh/asdb9uA==",
       "dependencies": {
-        "@algolia/cache-common": "4.14.2",
-        "@algolia/logger-common": "4.14.2",
-        "@algolia/requester-common": "4.14.2"
+        "@algolia/cache-common": "4.17.0",
+        "@algolia/logger-common": "4.17.0",
+        "@algolia/requester-common": "4.17.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1892,11 +1893,11 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.0.tgz",
-      "integrity": "sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
+      "integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1970,18 +1971,18 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.2.1.tgz",
-      "integrity": "sha512-gaP6TxxwQC+K8D6TRx5WULUWKrcbzECOPA2KCVMuI+6C7dNiGUk5yXXzVhc5sld79XKYLnO9DRTI4mjXDYkh+g=="
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.4.tgz",
+      "integrity": "sha512-vDwCDoVXDgopw/hvr0zEADew2wWaGP8Qq0Bxhgii1Ewz2t4fQeyJwIRN/mWADeLFYPVkpz8TpEbxya/i6Tm0WA=="
     },
     "node_modules/@docsearch/react": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.2.1.tgz",
-      "integrity": "sha512-EzTQ/y82s14IQC5XVestiK/kFFMe2aagoYFuTAIfIb/e+4FU7kSMKonRtLwsCiLQHmjvNQq+HO+33giJ5YVtaQ==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.4.tgz",
+      "integrity": "sha512-aeOf1WC5zMzBEi2SI6WWznOmIo9rnpN4p7a3zHXxowVciqlI4HsZGtOR9nFOufLeolv7HibwLlaM0oyUqJxasw==",
       "dependencies": {
-        "@algolia/autocomplete-core": "1.7.1",
-        "@algolia/autocomplete-preset-algolia": "1.7.1",
-        "@docsearch/css": "3.2.1",
+        "@algolia/autocomplete-core": "1.8.2",
+        "@algolia/autocomplete-preset-algolia": "1.8.2",
+        "@docsearch/css": "3.3.4",
         "algoliasearch": "^4.0.0"
       },
       "peerDependencies": {
@@ -2002,9 +2003,9 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.4.1.tgz",
+      "integrity": "sha512-SNsY7PshK3Ri7vtsLXVeAJGS50nJN3RgF836zkyUfAD01Fq+sAk5EwWgLw+nnm5KVNGDu7PRR2kRGDsWvqpo0g==",
       "dependencies": {
         "@babel/core": "^7.18.6",
         "@babel/generator": "^7.18.7",
@@ -2016,13 +2017,13 @@
         "@babel/runtime": "^7.18.6",
         "@babel/runtime-corejs3": "^7.18.6",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/cssnano-preset": "2.4.1",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/mdx-loader": "2.4.1",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-common": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.2.1",
         "autoprefixer": "^10.4.7",
@@ -2043,7 +2044,7 @@
         "del": "^6.1.1",
         "detect-port": "^1.3.0",
         "escape-html": "^1.0.3",
-        "eta": "^1.12.3",
+        "eta": "^2.0.0",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.1.0",
         "html-minifier-terser": "^6.1.0",
@@ -2090,9 +2091,9 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
-      "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.4.1.tgz",
+      "integrity": "sha512-ka+vqXwtcW1NbXxWsh6yA1Ckii1klY9E53cJ4O9J09nkMBgrNX3iEFED1fWdv8wf4mJjvGi5RLZ2p9hJNjsLyQ==",
       "dependencies": {
         "cssnano-preset-advanced": "^5.3.8",
         "postcss": "^8.4.14",
@@ -2104,9 +2105,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.1.0.tgz",
-      "integrity": "sha512-uuJx2T6hDBg82joFeyobywPjSOIfeq05GfyKGHThVoXuXsu1KAzMDYcjoDxarb9CoHCI/Dor8R2MoL6zII8x1Q==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.4.1.tgz",
+      "integrity": "sha512-5h5ysIIWYIDHyTVd8BjheZmQZmEgWDR54aQ1BX9pjFfpyzFo5puKXKYrYJXbjEHGyVhEzmB9UXwbxGfaZhOjcg==",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.4.0"
@@ -2116,14 +2117,14 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.1.0.tgz",
-      "integrity": "sha512-i97hi7hbQjsD3/8OSFhLy7dbKGH8ryjEzOfyhQIn2CFBYOY3ko0vMVEf3IY9nD3Ld7amYzsZ8153RPkcnXA+Lg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.4.1.tgz",
+      "integrity": "sha512-4KhUhEavteIAmbBj7LVFnrVYDiU51H5YWW1zY6SmBSte/YLhDutztLTBE0PQl1Grux1jzUJeaSvAzHpTn6JJDQ==",
       "dependencies": {
         "@babel/parser": "^7.18.8",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -2147,12 +2148,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.1.0.tgz",
-      "integrity": "sha512-Z8WZaK5cis3xEtyfOT817u9xgGUauT0PuuVo85ysnFRX8n7qLN1lTPCkC+aCmFm/UcV8h/W5T4NtIsst94UntQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.4.1.tgz",
+      "integrity": "sha512-gLBuIFM8Dp2XOCWffUDSjtxY7jQgKvYujt7Mx5s4FCTfoL5dN1EVbnrn+O2Wvh8b0a77D57qoIDY7ghgmatR1A==",
       "dependencies": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.1.0",
+        "@docusaurus/types": "2.4.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2166,17 +2167,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.1.0.tgz",
-      "integrity": "sha512-xEp6jlu92HMNUmyRBEeJ4mCW1s77aAEQO4Keez94cUY/Ap7G/r0Awa6xSLff7HL0Fjg8KK1bEbDy7q9voIavdg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.4.1.tgz",
+      "integrity": "sha512-E2i7Knz5YIbE1XELI6RlTnZnGgS52cUO4BlCiCUCvQHbR+s1xeIWz4C6BtaVnlug0Ccz7nFSksfwDpVlkujg5Q==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/mdx-loader": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-common": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^10.1.0",
@@ -2196,17 +2197,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.1.0.tgz",
-      "integrity": "sha512-Rup5pqXrXlKGIC4VgwvioIhGWF7E/NNSlxv+JAxRYpik8VKlWsk9ysrdHIlpX+KJUCO9irnY21kQh2814mlp/Q==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.4.1.tgz",
+      "integrity": "sha512-Lo7lSIcpswa2Kv4HEeUcGYqaasMUQNpjTXpV0N8G6jXgZaQurqp7E8NGYeGbDXnb48czmHWbzDL4S3+BbK0VzA==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/mdx-loader": "2.4.1",
+        "@docusaurus/module-type-aliases": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "@types/react-router-config": "^5.0.6",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.1.0",
@@ -2226,15 +2227,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.1.0.tgz",
-      "integrity": "sha512-SwZdDZRlObHNKXTnFo7W2aF6U5ZqNVI55Nw2GCBryL7oKQSLeI0lsrMlMXdzn+fS7OuBTd3MJBO1T4Zpz0i/+g==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.4.1.tgz",
+      "integrity": "sha512-/UjuH/76KLaUlL+o1OvyORynv6FURzjurSjvn2lbWTFc4tpYY2qLYTlKpTCBVPhlLUQsfyFnshEJDLmPneq2oA==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/mdx-loader": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
@@ -2248,13 +2249,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.1.0.tgz",
-      "integrity": "sha512-8wsDq3OIfiy6440KLlp/qT5uk+WRHQXIXklNHEeZcar+Of0TZxCNe2FBpv+bzb/0qcdP45ia5i5WmR5OjN6DPw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.4.1.tgz",
+      "integrity": "sha512-7Yu9UPzRShlrH/G8btOpR0e6INFZr0EegWplMjOqelIwAcx3PKyR8mgPTxGTxcqiYj6hxSCRN0D8R7YrzImwNA==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
@@ -2268,13 +2269,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.1.0.tgz",
-      "integrity": "sha512-4cgeqIly/wcFVbbWP03y1QJJBgH8W+Bv6AVbWnsXNOZa1yB3AO6hf3ZdeQH9x20v9T2pREogVgAH0rSoVnNsgg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.4.1.tgz",
+      "integrity": "sha512-dyZJdJiCoL+rcfnm0RPkLt/o732HvLiEwmtoNzOoz9MSZz117UH2J6U2vUDtzUzwtFLIf32KkeyzisbwUCgcaQ==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2286,13 +2287,31 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.1.0.tgz",
-      "integrity": "sha512-/3aDlv2dMoCeiX2e+DTGvvrdTA+v3cKQV3DbmfsF4ENhvc5nKV23nth04Z3Vq0Ci1ui6Sn80TkhGk/tiCMW2AA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.4.1.tgz",
+      "integrity": "sha512-mKIefK+2kGTQBYvloNEKtDmnRD7bxHLsBcxgnbt4oZwzi2nxCGjPX6+9SQO2KCN5HZbNrYmGo5GJfMgoRvy6uA==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-google-tag-manager": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-2.4.1.tgz",
+      "integrity": "sha512-Zg4Ii9CMOLfpeV2nG74lVTWNtisFaH9QNtEw48R5QE1KIwDBdTVaiSA18G1EujZjrzJJzXN79VhINSbOJO/r3g==",
+      "dependencies": {
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -2304,16 +2323,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.1.0.tgz",
-      "integrity": "sha512-2Y6Br8drlrZ/jN9MwMBl0aoi9GAjpfyfMBYpaQZXimbK+e9VjYnujXlvQ4SxtM60ASDgtHIAzfVFBkSR/MwRUw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.4.1.tgz",
+      "integrity": "sha512-lZx+ijt/+atQ3FVE8FOHV/+X3kuok688OydDXrqKRJyXBJZKgGjA2Qa8RjQ4f27V2woaXhtnyrdPop/+OjVMRg==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-common": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
@@ -2327,22 +2346,23 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.1.0.tgz",
-      "integrity": "sha512-NQMnaq974K4BcSMXFSJBQ5itniw6RSyW+VT+6i90kGZzTwiuKZmsp0r9lC6BYAvvVMQUNJQwrETmlu7y2XKW7w==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.4.1.tgz",
+      "integrity": "sha512-P4//+I4zDqQJ+UDgoFrjIFaQ1MeS9UD1cvxVQaI6O7iBmiHQm0MGROP1TbE7HlxlDPXFJjZUK3x3cAoK63smGQ==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/plugin-debug": "2.1.0",
-        "@docusaurus/plugin-google-analytics": "2.1.0",
-        "@docusaurus/plugin-google-gtag": "2.1.0",
-        "@docusaurus/plugin-sitemap": "2.1.0",
-        "@docusaurus/theme-classic": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-search-algolia": "2.1.0",
-        "@docusaurus/types": "2.1.0"
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/plugin-content-blog": "2.4.1",
+        "@docusaurus/plugin-content-docs": "2.4.1",
+        "@docusaurus/plugin-content-pages": "2.4.1",
+        "@docusaurus/plugin-debug": "2.4.1",
+        "@docusaurus/plugin-google-analytics": "2.4.1",
+        "@docusaurus/plugin-google-gtag": "2.4.1",
+        "@docusaurus/plugin-google-tag-manager": "2.4.1",
+        "@docusaurus/plugin-sitemap": "2.4.1",
+        "@docusaurus/theme-classic": "2.4.1",
+        "@docusaurus/theme-common": "2.4.1",
+        "@docusaurus/theme-search-algolia": "2.4.1",
+        "@docusaurus/types": "2.4.1"
       },
       "engines": {
         "node": ">=16.14"
@@ -2365,26 +2385,26 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.1.0.tgz",
-      "integrity": "sha512-xn8ZfNMsf7gaSy9+ClFnUu71o7oKgMo5noYSS1hy3svNifRTkrBp6+MReLDsmIaj3mLf2e7+JCBYKBFbaGzQng==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.4.1.tgz",
+      "integrity": "sha512-Rz0wKUa+LTW1PLXmwnf8mn85EBzaGSt6qamqtmnh9Hflkc+EqiYMhtUJeLdV+wsgYq4aG0ANc+bpUDpsUhdnwg==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-translations": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/mdx-loader": "2.4.1",
+        "@docusaurus/module-type-aliases": "2.4.1",
+        "@docusaurus/plugin-content-blog": "2.4.1",
+        "@docusaurus/plugin-content-docs": "2.4.1",
+        "@docusaurus/plugin-content-pages": "2.4.1",
+        "@docusaurus/theme-common": "2.4.1",
+        "@docusaurus/theme-translations": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-common": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "copy-text-to-clipboard": "^3.0.1",
-        "infima": "0.2.0-alpha.42",
+        "infima": "0.2.0-alpha.43",
         "lodash": "^4.17.21",
         "nprogress": "^0.2.0",
         "postcss": "^8.4.14",
@@ -2404,16 +2424,17 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.1.0.tgz",
-      "integrity": "sha512-vT1otpVPbKux90YpZUnvknsn5zvpLf+AW1W0EDcpE9up4cDrPqfsh0QoxGHFJnobE2/qftsBFC19BneN4BH8Ag==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.4.1.tgz",
+      "integrity": "sha512-G7Zau1W5rQTaFFB3x3soQoZpkgMbl/SYNG8PfMFIjKa3M3q8n0m/GRf5/H/e5BqOvt8c+ZWIXGCiz+kUCSHovA==",
       "dependencies": {
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/mdx-loader": "2.4.1",
+        "@docusaurus/module-type-aliases": "2.4.1",
+        "@docusaurus/plugin-content-blog": "2.4.1",
+        "@docusaurus/plugin-content-docs": "2.4.1",
+        "@docusaurus/plugin-content-pages": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-common": "2.4.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2421,6 +2442,7 @@
         "parse-numeric-range": "^1.3.0",
         "prism-react-renderer": "^1.3.5",
         "tslib": "^2.4.0",
+        "use-sync-external-store": "^1.2.0",
         "utility-types": "^3.10.0"
       },
       "engines": {
@@ -2432,22 +2454,22 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.1.0.tgz",
-      "integrity": "sha512-rNBvi35VvENhucslEeVPOtbAzBdZY/9j55gdsweGV5bYoAXy4mHB6zTGjealcB4pJ6lJY4a5g75fXXMOlUqPfg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.4.1.tgz",
+      "integrity": "sha512-6BcqW2lnLhZCXuMAvPRezFs1DpmEKzXFKlYjruuas+Xy3AQeFzDJKTJFIm49N77WFCTyxff8d3E4Q9pi/+5McQ==",
       "dependencies": {
         "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-translations": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/plugin-content-docs": "2.4.1",
+        "@docusaurus/theme-common": "2.4.1",
+        "@docusaurus/theme-translations": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "algoliasearch": "^4.13.1",
         "algoliasearch-helper": "^3.10.0",
         "clsx": "^1.2.1",
-        "eta": "^1.12.3",
+        "eta": "^2.0.0",
         "fs-extra": "^10.1.0",
         "lodash": "^4.17.21",
         "tslib": "^2.4.0",
@@ -2462,9 +2484,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.1.0.tgz",
-      "integrity": "sha512-07n2akf2nqWvtJeMy3A+7oSGMuu5F673AovXVwY0aGAux1afzGCiqIFlYW3EP0CujvDJAEFSQi/Tetfh+95JNg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.4.1.tgz",
+      "integrity": "sha512-T1RAGP+f86CA1kfE8ejZ3T3pUU3XcyvrGMfC/zxCtc2BsnoexuNI9Vk2CmuKCb+Tacvhxjv5unhxXce0+NKyvA==",
       "dependencies": {
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0"
@@ -2474,9 +2496,9 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.1.0.tgz",
-      "integrity": "sha512-BS1ebpJZnGG6esKqsjtEC9U9qSaPylPwlO7cQ1GaIE7J/kMZI3FITnNn0otXXu7c7ZTqhb6+8dOrG6fZn6fqzQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.4.1.tgz",
+      "integrity": "sha512-0R+cbhpMkhbRXX138UOc/2XZFF8hiZa6ooZAEEJFp5scytzCw4tC1gChMFXrpa3d2tYE6AX8IrOEpSonLmfQuQ==",
       "dependencies": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
@@ -2493,12 +2515,13 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.1.0.tgz",
-      "integrity": "sha512-fPvrfmAuC54n8MjZuG4IysaMdmvN5A/qr7iFLbSGSyDrsbP4fnui6KdZZIa/YOLIPLec8vjZ8RIITJqF18mx4A==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.4.1.tgz",
+      "integrity": "sha512-1lvEZdAQhKNht9aPXPoh69eeKnV0/62ROhQeFKKxmzd0zkcuE/Oc5Gpnt00y/f5bIsmOsYMY7Pqfm/5rteT5GA==",
       "dependencies": {
-        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/logger": "2.4.1",
         "@svgr/webpack": "^6.2.1",
+        "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.1.0",
         "github-slugger": "^1.4.0",
@@ -2526,9 +2549,9 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.1.0.tgz",
-      "integrity": "sha512-F2vgmt4yRFgRQR2vyEFGTWeyAdmgKbtmu3sjHObF0tjjx/pN0Iw/c6eCopaH34E6tc9nO0nvp01pwW+/86d1fg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.4.1.tgz",
+      "integrity": "sha512-bCVGdZU+z/qVcIiEQdyx0K13OC5mYwxhSuDUR95oFbKVuXYRrTVrwZIqQljuo1fyJvFTKHiL9L9skQOPokuFNQ==",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -2545,12 +2568,12 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.1.0.tgz",
-      "integrity": "sha512-AMJzWYKL3b7FLltKtDXNLO9Y649V2BXvrnRdnW2AA+PpBnYV78zKLSCz135cuWwRj1ajNtP4onbXdlnyvCijGQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.4.1.tgz",
+      "integrity": "sha512-unII3hlJlDwZ3w8U+pMO3Lx3RhI4YEbY3YNsQj4yzrkZzlpqZOLuAiZK2JyULnD+TKbceKU0WyWkQXtYbLNDFA==",
       "dependencies": {
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
         "joi": "^17.6.0",
         "js-yaml": "^4.1.0",
         "tslib": "^2.4.0"
@@ -3819,30 +3842,30 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.2.tgz",
-      "integrity": "sha512-ngbEQonGEmf8dyEh5f+uOIihv4176dgbuOZspiuhmTTBRBuzWu3KCGHre6uHj5YyuC7pNvQGzB6ZNJyZi0z+Sg==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.17.0.tgz",
+      "integrity": "sha512-JMRh2Mw6sEnVMiz6+APsi7lx9a2jiDFF+WUtANaUVCv6uSU9UOLdo5h9K3pdP6frRRybaM2fX8b1u0nqICS9aA==",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.14.2",
-        "@algolia/cache-common": "4.14.2",
-        "@algolia/cache-in-memory": "4.14.2",
-        "@algolia/client-account": "4.14.2",
-        "@algolia/client-analytics": "4.14.2",
-        "@algolia/client-common": "4.14.2",
-        "@algolia/client-personalization": "4.14.2",
-        "@algolia/client-search": "4.14.2",
-        "@algolia/logger-common": "4.14.2",
-        "@algolia/logger-console": "4.14.2",
-        "@algolia/requester-browser-xhr": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/requester-node-http": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/cache-browser-local-storage": "4.17.0",
+        "@algolia/cache-common": "4.17.0",
+        "@algolia/cache-in-memory": "4.17.0",
+        "@algolia/client-account": "4.17.0",
+        "@algolia/client-analytics": "4.17.0",
+        "@algolia/client-common": "4.17.0",
+        "@algolia/client-personalization": "4.17.0",
+        "@algolia/client-search": "4.17.0",
+        "@algolia/logger-common": "4.17.0",
+        "@algolia/logger-console": "4.17.0",
+        "@algolia/requester-browser-xhr": "4.17.0",
+        "@algolia/requester-common": "4.17.0",
+        "@algolia/requester-node-http": "4.17.0",
+        "@algolia/transporter": "4.17.0"
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.11.1.tgz",
-      "integrity": "sha512-mvsPN3eK4E0bZG0/WlWJjeqe/bUD2KOEVOl0GyL/TGXn6wcpZU8NOuztGHCUKXkyg5gq6YzUakVTmnmSSO5Yiw==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.13.0.tgz",
+      "integrity": "sha512-kV3c1jMQCvkARtGsSDvAwuht4PAMSsQILqPiH4WFiARoa3jXJ/r1TQoBWAjWyWF48rsNYCv7kzxgB4LTxrvvuw==",
       "dependencies": {
         "@algolia/events": "^4.0.1"
       },
@@ -3963,9 +3986,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.9",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.9.tgz",
-      "integrity": "sha512-Uu67eduPEmOeA0vyJby5ghu1AAELCCNSsLAjK+lz6kYzNM5sqnBO36MqfsjhPjQF/BaJM5U/UuFYyl7PavY/wQ==",
+      "version": "10.4.14",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
+      "integrity": "sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -3977,8 +4000,8 @@
         }
       ],
       "dependencies": {
-        "browserslist": "^4.21.3",
-        "caniuse-lite": "^1.0.30001394",
+        "browserslist": "^4.21.5",
+        "caniuse-lite": "^1.0.30001464",
         "fraction.js": "^4.2.0",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -4257,9 +4280,9 @@
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
     },
     "node_modules/browserslist": {
-      "version": "4.21.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
-      "integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
+      "version": "4.21.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
       "funding": [
         {
           "type": "opencollective",
@@ -4271,10 +4294,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001370",
-        "electron-to-chromium": "^1.4.202",
-        "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.5"
+        "caniuse-lite": "^1.0.30001449",
+        "electron-to-chromium": "^1.4.284",
+        "node-releases": "^2.0.8",
+        "update-browserslist-db": "^1.0.10"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4403,9 +4426,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001397",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001397.tgz",
-      "integrity": "sha512-SW9N2TbCdLf0eiNDRrrQXx2sOkaakNZbCjgNpPyMJJbiOrU5QzMIrXOVMRM1myBXTD5iTkdrtU/EguCrBocHlA==",
+      "version": "1.0.30001487",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001487.tgz",
+      "integrity": "sha512-83564Z3yWGqXsh2vaH/mhXfEM0wX+NlBCm1jYHOb97TrTWJEmPTccZgeLTPBUUb0PNVo+oomb7wkimZBIERClA==",
       "funding": [
         {
           "type": "opencollective",
@@ -4414,6 +4437,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -4834,9 +4861,9 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "node_modules/copy-text-to-clipboard": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.0.1.tgz",
-      "integrity": "sha512-rvVsHrpFcL4F2P8ihsoLdFHmd404+CMg71S756oRSeQgqk51U3kicGdnvfkrxva0xXH92SjGS62B0XIJsbh+9Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.1.0.tgz",
+      "integrity": "sha512-PFM6BnjLnOON/lB3ta/Jg7Ywsv+l9kQGD4TWDCSlRBGmqnnTM5MrDkhAFgw+8HZt0wW6Q2BBE4cmy9sq+s9Qng==",
       "engines": {
         "node": ">=12"
       },
@@ -5009,11 +5036,11 @@
       }
     },
     "node_modules/cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.6.tgz",
+      "integrity": "sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==",
       "dependencies": {
-        "node-fetch": "2.6.7"
+        "node-fetch": "^2.6.11"
       }
     },
     "node_modules/cross-spawn": {
@@ -5232,12 +5259,12 @@
       }
     },
     "node_modules/cssnano-preset-advanced": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.3.8.tgz",
-      "integrity": "sha512-xUlLLnEB1LjpEik+zgRNlk8Y/koBPPtONZjp7JKbXigeAmCrFvq9H0pXW5jJV45bQWAlmJ0sKy+IMr0XxLYQZg==",
+      "version": "5.3.10",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.3.10.tgz",
+      "integrity": "sha512-fnYJyCS9jgMU+cmHO1rPSPf9axbQyD7iUhLO5Df6O4G+fKIOMps+ZbU0PdGFejFBBZ3Pftf18fn1eG7MAPUSWQ==",
       "dependencies": {
-        "autoprefixer": "^10.3.7",
-        "cssnano-preset-default": "^5.2.12",
+        "autoprefixer": "^10.4.12",
+        "cssnano-preset-default": "^5.2.14",
         "postcss-discard-unused": "^5.1.0",
         "postcss-merge-idents": "^5.1.1",
         "postcss-reduce-idents": "^5.2.0",
@@ -5251,24 +5278,24 @@
       }
     },
     "node_modules/cssnano-preset-default": {
-      "version": "5.2.12",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.12.tgz",
-      "integrity": "sha512-OyCBTZi+PXgylz9HAA5kHyoYhfGcYdwFmyaJzWnzxuGRtnMw/kR6ilW9XzlzlRAtB6PLT/r+prYgkef7hngFew==",
+      "version": "5.2.14",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.14.tgz",
+      "integrity": "sha512-t0SFesj/ZV2OTylqQVOrFgEh5uanxbO6ZAdeCrNsUQ6fVuXwYTxJPNAGvGTxHbD68ldIJNec7PyYZDBrfDQ+6A==",
       "dependencies": {
-        "css-declaration-sorter": "^6.3.0",
+        "css-declaration-sorter": "^6.3.1",
         "cssnano-utils": "^3.1.0",
         "postcss-calc": "^8.2.3",
-        "postcss-colormin": "^5.3.0",
-        "postcss-convert-values": "^5.1.2",
+        "postcss-colormin": "^5.3.1",
+        "postcss-convert-values": "^5.1.3",
         "postcss-discard-comments": "^5.1.2",
         "postcss-discard-duplicates": "^5.1.0",
         "postcss-discard-empty": "^5.1.1",
         "postcss-discard-overridden": "^5.1.0",
-        "postcss-merge-longhand": "^5.1.6",
-        "postcss-merge-rules": "^5.1.2",
+        "postcss-merge-longhand": "^5.1.7",
+        "postcss-merge-rules": "^5.1.4",
         "postcss-minify-font-values": "^5.1.0",
         "postcss-minify-gradients": "^5.1.1",
-        "postcss-minify-params": "^5.1.3",
+        "postcss-minify-params": "^5.1.4",
         "postcss-minify-selectors": "^5.2.1",
         "postcss-normalize-charset": "^5.1.0",
         "postcss-normalize-display-values": "^5.1.0",
@@ -5276,11 +5303,11 @@
         "postcss-normalize-repeat-style": "^5.1.1",
         "postcss-normalize-string": "^5.1.0",
         "postcss-normalize-timing-functions": "^5.1.0",
-        "postcss-normalize-unicode": "^5.1.0",
+        "postcss-normalize-unicode": "^5.1.1",
         "postcss-normalize-url": "^5.1.0",
         "postcss-normalize-whitespace": "^5.1.1",
         "postcss-ordered-values": "^5.1.3",
-        "postcss-reduce-initial": "^5.1.0",
+        "postcss-reduce-initial": "^5.1.2",
         "postcss-reduce-transforms": "^5.1.0",
         "postcss-svgo": "^5.1.0",
         "postcss-unique-selectors": "^5.1.1"
@@ -5632,6 +5659,329 @@
         "node": ">=6"
       }
     },
+    "node_modules/docusaurus-theme-search-typesense": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/docusaurus-theme-search-typesense/-/docusaurus-theme-search-typesense-0.11.0.tgz",
+      "integrity": "sha512-nIWJVFSN+q2lJmAVkgqC6+XqBEiGorB5c6YDjmFQO28HIDynWJQchDVHgaeB4440Kk6PxrzwraNr+SHyZKVrtw==",
+      "dependencies": {
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/plugin-content-docs": "2.4.0",
+        "@docusaurus/theme-translations": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
+        "algoliasearch-helper": "^3.10.0",
+        "clsx": "^1.2.1",
+        "eta": "^2.0.0",
+        "fs-extra": "^10.1.0",
+        "lodash": "^4.17.21",
+        "tslib": "^2.4.0",
+        "typesense-docsearch-react": "^3.4.0",
+        "typesense-instantsearch-adapter": "^2.6.0",
+        "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/theme-common": "2.4.0",
+        "react": "^16.8.4 || ^17.0.2",
+        "react-dom": "^16.8.4 || ^17.0.2"
+      }
+    },
+    "node_modules/docusaurus-theme-search-typesense/node_modules/@docusaurus/cssnano-preset": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.4.0.tgz",
+      "integrity": "sha512-RmdiA3IpsLgZGXRzqnmTbGv43W4OD44PCo+6Q/aYjEM2V57vKCVqNzuafE94jv0z/PjHoXUrjr69SaRymBKYYw==",
+      "dependencies": {
+        "cssnano-preset-advanced": "^5.3.8",
+        "postcss": "^8.4.14",
+        "postcss-sort-media-queries": "^4.2.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
+    "node_modules/docusaurus-theme-search-typesense/node_modules/@docusaurus/logger": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.4.0.tgz",
+      "integrity": "sha512-T8+qR4APN+MjcC9yL2Es+xPJ2923S9hpzDmMtdsOcUGLqpCGBbU1vp3AAqDwXtVgFkq+NsEk7sHdVsfLWR/AXw==",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
+    "node_modules/docusaurus-theme-search-typesense/node_modules/@docusaurus/mdx-loader": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.4.0.tgz",
+      "integrity": "sha512-GWoH4izZKOmFoC+gbI2/y8deH/xKLvzz/T5BsEexBye8EHQlwsA7FMrVa48N063bJBH4FUOiRRXxk5rq9cC36g==",
+      "dependencies": {
+        "@babel/parser": "^7.18.8",
+        "@babel/traverse": "^7.18.8",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@mdx-js/mdx": "^1.6.22",
+        "escape-html": "^1.0.3",
+        "file-loader": "^6.2.0",
+        "fs-extra": "^10.1.0",
+        "image-size": "^1.0.1",
+        "mdast-util-to-string": "^2.0.0",
+        "remark-emoji": "^2.2.0",
+        "stringify-object": "^3.3.0",
+        "tslib": "^2.4.0",
+        "unified": "^9.2.2",
+        "unist-util-visit": "^2.0.3",
+        "url-loader": "^4.1.1",
+        "webpack": "^5.73.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/docusaurus-theme-search-typesense/node_modules/@docusaurus/module-type-aliases": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.4.0.tgz",
+      "integrity": "sha512-YEQO2D3UXs72qCn8Cr+RlycSQXVGN9iEUyuHwTuK4/uL/HFomB2FHSU0vSDM23oLd+X/KibQ3Ez6nGjQLqXcHg==",
+      "dependencies": {
+        "@docusaurus/react-loadable": "5.5.2",
+        "@docusaurus/types": "2.4.0",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router-config": "*",
+        "@types/react-router-dom": "*",
+        "react-helmet-async": "*",
+        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/docusaurus-theme-search-typesense/node_modules/@docusaurus/plugin-content-docs": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.4.0.tgz",
+      "integrity": "sha512-ic/Z/ZN5Rk/RQo+Io6rUGpToOtNbtPloMR2JcGwC1xT2riMu6zzfSwmBi9tHJgdXH6CB5jG+0dOZZO8QS5tmDg==",
+      "dependencies": {
+        "@docusaurus/core": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/module-type-aliases": "2.4.0",
+        "@docusaurus/types": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
+        "@types/react-router-config": "^5.0.6",
+        "combine-promises": "^1.1.0",
+        "fs-extra": "^10.1.0",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "tslib": "^2.4.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.73.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/docusaurus-theme-search-typesense/node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/core": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.4.0.tgz",
+      "integrity": "sha512-J55/WEoIpRcLf3afO5POHPguVZosKmJEQWKBL+K7TAnfuE7i+Y0NPLlkKtnWCehagGsgTqClfQEexH/UT4kELA==",
+      "dependencies": {
+        "@babel/core": "^7.18.6",
+        "@babel/generator": "^7.18.7",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-transform-runtime": "^7.18.6",
+        "@babel/preset-env": "^7.18.6",
+        "@babel/preset-react": "^7.18.6",
+        "@babel/preset-typescript": "^7.18.6",
+        "@babel/runtime": "^7.18.6",
+        "@babel/runtime-corejs3": "^7.18.6",
+        "@babel/traverse": "^7.18.8",
+        "@docusaurus/cssnano-preset": "2.4.0",
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/mdx-loader": "2.4.0",
+        "@docusaurus/react-loadable": "5.5.2",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-common": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
+        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
+        "@svgr/webpack": "^6.2.1",
+        "autoprefixer": "^10.4.7",
+        "babel-loader": "^8.2.5",
+        "babel-plugin-dynamic-import-node": "^2.3.3",
+        "boxen": "^6.2.1",
+        "chalk": "^4.1.2",
+        "chokidar": "^3.5.3",
+        "clean-css": "^5.3.0",
+        "cli-table3": "^0.6.2",
+        "combine-promises": "^1.1.0",
+        "commander": "^5.1.0",
+        "copy-webpack-plugin": "^11.0.0",
+        "core-js": "^3.23.3",
+        "css-loader": "^6.7.1",
+        "css-minimizer-webpack-plugin": "^4.0.0",
+        "cssnano": "^5.1.12",
+        "del": "^6.1.1",
+        "detect-port": "^1.3.0",
+        "escape-html": "^1.0.3",
+        "eta": "^2.0.0",
+        "file-loader": "^6.2.0",
+        "fs-extra": "^10.1.0",
+        "html-minifier-terser": "^6.1.0",
+        "html-tags": "^3.2.0",
+        "html-webpack-plugin": "^5.5.0",
+        "import-fresh": "^3.3.0",
+        "leven": "^3.1.0",
+        "lodash": "^4.17.21",
+        "mini-css-extract-plugin": "^2.6.1",
+        "postcss": "^8.4.14",
+        "postcss-loader": "^7.0.0",
+        "prompts": "^2.4.2",
+        "react-dev-utils": "^12.0.1",
+        "react-helmet-async": "^1.3.0",
+        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
+        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
+        "react-router": "^5.3.3",
+        "react-router-config": "^5.1.1",
+        "react-router-dom": "^5.3.3",
+        "rtl-detect": "^1.0.4",
+        "semver": "^7.3.7",
+        "serve-handler": "^6.1.3",
+        "shelljs": "^0.8.5",
+        "terser-webpack-plugin": "^5.3.3",
+        "tslib": "^2.4.0",
+        "update-notifier": "^5.1.0",
+        "url-loader": "^4.1.1",
+        "wait-on": "^6.0.1",
+        "webpack": "^5.73.0",
+        "webpack-bundle-analyzer": "^4.5.0",
+        "webpack-dev-server": "^4.9.3",
+        "webpack-merge": "^5.8.0",
+        "webpackbar": "^5.0.2"
+      },
+      "bin": {
+        "docusaurus": "bin/docusaurus.mjs"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/docusaurus-theme-search-typesense/node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/core/node_modules/@docusaurus/utils-common": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.4.0.tgz",
+      "integrity": "sha512-zIMf10xuKxddYfLg5cS19x44zud/E9I7lj3+0bv8UIs0aahpErfNrGhijEfJpAfikhQ8tL3m35nH3hJ3sOG82A==",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "@docusaurus/types": "*"
+      },
+      "peerDependenciesMeta": {
+        "@docusaurus/types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/docusaurus-theme-search-typesense/node_modules/@docusaurus/theme-translations": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.4.0.tgz",
+      "integrity": "sha512-kEoITnPXzDPUMBHk3+fzEzbopxLD3fR5sDoayNH0vXkpUukA88/aDL1bqkhxWZHA3LOfJ3f0vJbOwmnXW5v85Q==",
+      "dependencies": {
+        "fs-extra": "^10.1.0",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
+    "node_modules/docusaurus-theme-search-typesense/node_modules/@docusaurus/types": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.4.0.tgz",
+      "integrity": "sha512-xaBXr+KIPDkIaef06c+i2HeTqVNixB7yFut5fBXPGI2f1rrmEV2vLMznNGsFwvZ5XmA3Quuefd4OGRkdo97Dhw==",
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.6.0",
+        "react-helmet-async": "^1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.73.0",
+        "webpack-merge": "^5.8.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/docusaurus-theme-search-typesense/node_modules/@docusaurus/utils": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.4.0.tgz",
+      "integrity": "sha512-89hLYkvtRX92j+C+ERYTuSUK6nF9bGM32QThcHPg2EDDHVw6FzYQXmX6/p+pU5SDyyx5nBlE4qXR92RxCAOqfg==",
+      "dependencies": {
+        "@docusaurus/logger": "2.4.0",
+        "@svgr/webpack": "^6.2.1",
+        "escape-string-regexp": "^4.0.0",
+        "file-loader": "^6.2.0",
+        "fs-extra": "^10.1.0",
+        "github-slugger": "^1.4.0",
+        "globby": "^11.1.0",
+        "gray-matter": "^4.0.3",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "micromatch": "^4.0.5",
+        "resolve-pathname": "^3.0.0",
+        "shelljs": "^0.8.5",
+        "tslib": "^2.4.0",
+        "url-loader": "^4.1.1",
+        "webpack": "^5.73.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "@docusaurus/types": "*"
+      },
+      "peerDependenciesMeta": {
+        "@docusaurus/types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/docusaurus-theme-search-typesense/node_modules/@docusaurus/utils-validation": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.4.0.tgz",
+      "integrity": "sha512-IrBsBbbAp6y7mZdJx4S4pIA7dUyWSA0GNosPk6ZJ0fX3uYIEQgcQSGIgTeSC+8xPEx3c16o03en1jSDpgQgz/w==",
+      "dependencies": {
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "joi": "^17.6.0",
+        "js-yaml": "^4.1.0",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
     "node_modules/dom-converter": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
@@ -5759,9 +6109,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.247",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.247.tgz",
-      "integrity": "sha512-FLs6R4FQE+1JHM0hh3sfdxnYjKvJpHZyhQDjc2qFq/xFvmmRt/TATNToZhrcGUFzpF2XjeiuozrA8lI0PZmYYw=="
+      "version": "1.4.396",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.396.tgz",
+      "integrity": "sha512-pqKTdqp/c5vsrc0xUPYXTDBo9ixZuGY8es4ZOjjd6HD6bFYbu5QA09VoW3fkY4LF1T0zYk86lN6bZnNlBuOpdQ=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -5958,9 +6308,9 @@
       }
     },
     "node_modules/eta": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/eta/-/eta-1.12.3.tgz",
-      "integrity": "sha512-qHixwbDLtekO/d51Yr4glcaUJCIjGVJyTzuqV4GPlgZo1YpgOKG+avQynErZIYrfM6JIJdtiG2Kox8tbb+DoGg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-2.1.2.tgz",
+      "integrity": "sha512-qWH+mERhihcwKE9+Ah37rLDTP0d3Qc5KEsnEQhvoBowDezVI2F6+bqjRBVY+auUYOUb94MI0x5fllZs+CWVRRQ==",
       "engines": {
         "node": ">=6.0.0"
       },
@@ -6361,9 +6711,9 @@
       }
     },
     "node_modules/flux": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.3.tgz",
-      "integrity": "sha512-yKAbrp7JhZhj6uiT1FTuVMlIAT1J4jqEyBpFApi1kxpGZCvacMVc/t1pMQyotqHhAgvoE3bNvAykhCo2CLjnYw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.4.tgz",
+      "integrity": "sha512-NCj3XlayA2UsapRpM7va6wU1+9rE5FIL7qoMcmxWHRzbp0yujihMBm9BBHZ1MDIk5h5o2Bl6eGiCe8rYELAmYw==",
       "dependencies": {
         "fbemitter": "^3.0.0",
         "fbjs": "^3.0.1"
@@ -7322,9 +7672,9 @@
       }
     },
     "node_modules/infima": {
-      "version": "0.2.0-alpha.42",
-      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.42.tgz",
-      "integrity": "sha512-ift8OXNbQQwtbIt6z16KnSWP7uJ/SysSMFI4F87MNRTicypfl4Pv3E2OGVv6N3nSZFJvA8imYulCBS64iyHYww==",
+      "version": "0.2.0-alpha.43",
+      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.43.tgz",
+      "integrity": "sha512-2uw57LvUqW0rK/SWYnd/2rRfxNA5DDNOh33jxF7fy46VWoNhGxiUQyVZHbBMjQ33mQem0cjdDVwgWVAmlRfgyQ==",
       "engines": {
         "node": ">=12"
       }
@@ -8050,6 +8400,18 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
     },
+    "node_modules/loglevel": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.1.tgz",
+      "integrity": "sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -8467,9 +8829,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -8494,9 +8856,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
-      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
+      "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -9038,11 +9400,11 @@
       }
     },
     "node_modules/postcss-colormin": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.3.0.tgz",
-      "integrity": "sha512-WdDO4gOFG2Z8n4P8TWBpshnL3JpmNmJwdnfP2gbk2qBA8PWwOYcmjmI/t3CmMeL72a7Hkd+x/Mg9O2/0rD54Pg==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.3.1.tgz",
+      "integrity": "sha512-UsWQG0AqTFQmpBegeLLc1+c3jIqBNB0zlDGRWR+dQ3pRKJL1oeMzyqmH3o2PIfn9MBdNrVPWhDbT769LxCTLJQ==",
       "dependencies": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "caniuse-api": "^3.0.0",
         "colord": "^2.9.1",
         "postcss-value-parser": "^4.2.0"
@@ -9055,11 +9417,11 @@
       }
     },
     "node_modules/postcss-convert-values": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.2.tgz",
-      "integrity": "sha512-c6Hzc4GAv95B7suy4udszX9Zy4ETyMCgFPUDtWjdFTKH1SE9eFY/jEpHSwTH1QPuwxHpWslhckUQWbNRM4ho5g==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.3.tgz",
+      "integrity": "sha512-82pC1xkJZtcJEfiLw6UXnXVXScgtBrjlO5CBmuDQc+dlb88ZYheFsjTn40+zBVi3DkfF7iezO0nJUPLcJK3pvA==",
       "dependencies": {
-        "browserslist": "^4.20.3",
+        "browserslist": "^4.21.4",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
@@ -9164,12 +9526,12 @@
       }
     },
     "node_modules/postcss-merge-longhand": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.6.tgz",
-      "integrity": "sha512-6C/UGF/3T5OE2CEbOuX7iNO63dnvqhGZeUnKkDeifebY0XqkkvrctYSZurpNE902LDf2yKwwPFgotnfSoPhQiw==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.7.tgz",
+      "integrity": "sha512-YCI9gZB+PLNskrK0BB3/2OzPnGhPkBEwmwhfYk1ilBHYVAZB7/tkTHFBAnCrvBBOmeYyMYw3DMjT55SyxMBzjQ==",
       "dependencies": {
         "postcss-value-parser": "^4.2.0",
-        "stylehacks": "^5.1.0"
+        "stylehacks": "^5.1.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
@@ -9179,11 +9541,11 @@
       }
     },
     "node_modules/postcss-merge-rules": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.2.tgz",
-      "integrity": "sha512-zKMUlnw+zYCWoPN6yhPjtcEdlJaMUZ0WyVcxTAmw3lkkN/NDMRkOkiuctQEoWAOvH7twaxUUdvBWl0d4+hifRQ==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.4.tgz",
+      "integrity": "sha512-0R2IuYpgU93y9lhVbO/OylTtKMVcHb67zjWIfCiKR9rWL3GUk1677LAqD/BcHizukdZEjT8Ru3oHRoAYoJy44g==",
       "dependencies": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "caniuse-api": "^3.0.0",
         "cssnano-utils": "^3.1.0",
         "postcss-selector-parser": "^6.0.5"
@@ -9226,11 +9588,11 @@
       }
     },
     "node_modules/postcss-minify-params": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.3.tgz",
-      "integrity": "sha512-bkzpWcjykkqIujNL+EVEPOlLYi/eZ050oImVtHU7b4lFS82jPnsCb44gvC6pxaNt38Els3jWYDHTjHKf0koTgg==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.4.tgz",
+      "integrity": "sha512-+mePA3MgdmVmv6g+30rn57USjOGSAyuxUmkfiWpzalZ8aiBkdPYjXWtHuwJGm1v5Ojy0Z0LaSYhHaLJQB0P8Jw==",
       "dependencies": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "cssnano-utils": "^3.1.0",
         "postcss-value-parser": "^4.2.0"
       },
@@ -9392,11 +9754,11 @@
       }
     },
     "node_modules/postcss-normalize-unicode": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.0.tgz",
-      "integrity": "sha512-J6M3MizAAZ2dOdSjy2caayJLQT8E8K9XjLce8AUQMwOrCvjCHv24aLC/Lps1R1ylOfol5VIDMaM/Lo9NGlk1SQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.1.tgz",
+      "integrity": "sha512-qnCL5jzkNUmKVhZoENp1mJiGNPcsJCs1aaRmURmeJGES23Z/ajaln+EPTD+rBeNkSryI+2WTdW+lwcVdOikrpA==",
       "dependencies": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
@@ -9465,11 +9827,11 @@
       }
     },
     "node_modules/postcss-reduce-initial": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.0.tgz",
-      "integrity": "sha512-5OgTUviz0aeH6MtBjHfbr57tml13PuedK/Ecg8szzd4XRMbYxH4572JFG067z+FqBIf6Zp/d+0581glkvvWMFw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.2.tgz",
+      "integrity": "sha512-dE/y2XRaqAi6OvjzD22pjTUQ8eOfc6m/natGHgKFBK9DxFmIm69YmaRVQrGgFlEfc1HePIurY0TmDeROK05rIg==",
       "dependencies": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "caniuse-api": "^3.0.0"
       },
       "engines": {
@@ -9506,9 +9868,9 @@
       }
     },
     "node_modules/postcss-sort-media-queries": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/postcss-sort-media-queries/-/postcss-sort-media-queries-4.3.0.tgz",
-      "integrity": "sha512-jAl8gJM2DvuIJiI9sL1CuiHtKM4s5aEIomkU8G3LFvbP+p8i7Sz8VV63uieTgoewGqKbi+hxBTiOKJlB35upCg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/postcss-sort-media-queries/-/postcss-sort-media-queries-4.4.1.tgz",
+      "integrity": "sha512-QDESFzDDGKgpiIh4GYXsSy6sek2yAwQx1JASl5AxBtU1Lq2JfKBljIPNdil989NcSKRQX1ToiaKphImtBuhXWw==",
       "dependencies": {
         "sort-css-media-queries": "2.1.0"
       },
@@ -10093,11 +10455,11 @@
       }
     },
     "node_modules/react-textarea-autosize": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.4.tgz",
-      "integrity": "sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.1.tgz",
+      "integrity": "sha512-aD2C+qK6QypknC+lCMzteOdIjoMbNlgSFmJjCV+DrfTPwp59i/it9mMNf2HDzvRjQgKAyBDPyLJhcrzElf2U4Q==",
       "dependencies": {
-        "@babel/runtime": "^7.10.2",
+        "@babel/runtime": "^7.20.13",
         "use-composed-ref": "^1.3.0",
         "use-latest": "^1.2.1"
       },
@@ -10187,9 +10549,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.0",
@@ -11393,11 +11755,11 @@
       }
     },
     "node_modules/stylehacks": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.0.tgz",
-      "integrity": "sha512-SzLmvHQTrIWfSgljkQCw2++C9+Ne91d/6Sp92I8c5uHTcy/PgeHamwITIbBW9wnFTY/3ZfSXR9HIL6Ikqmcu6Q==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.1.tgz",
+      "integrity": "sha512-sBpcd5Hx7G6seo7b1LkpttvTz7ikD0LlH5RmdcBNb6fFR0Fl7LQwHDFr300q4cwUqi+IYrFGmsIHieMBfnN/Bw==",
       "dependencies": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "postcss-selector-parser": "^6.0.4"
       },
       "engines": {
@@ -11810,10 +12172,75 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/typesense": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/typesense/-/typesense-1.5.3.tgz",
+      "integrity": "sha512-eLHBP6AHex04tT+q/a7Uc+dFjIuoKTRpvlsNJwVTyedh4n0qnJxbfoLJBCxzhhZn5eITjEK0oWvVZ5byc3E+Ww==",
+      "dependencies": {
+        "axios": "^0.26.0",
+        "loglevel": "^1.8.0"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "^7.17.2"
+      }
+    },
+    "node_modules/typesense-docsearch-css": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/typesense-docsearch-css/-/typesense-docsearch-css-0.4.0.tgz",
+      "integrity": "sha512-hVTJC1Rg2BnNB4kl2Qi4GcgjFmPZY8YGu0aJ5V6iM6vK62yvtE7jObnAc1maYOp33NWFVLPgl/9PlBfWBlN0Dw=="
+    },
+    "node_modules/typesense-docsearch-react": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/typesense-docsearch-react/-/typesense-docsearch-react-3.4.0.tgz",
+      "integrity": "sha512-87M0ktGiSmJ4m9VpJKC3gD6w31ZhctdB34c6aguLJXsiLDydNF+ipBYuCYE26D47rx/KLk82rsiZwovjaagZnw==",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.8.2",
+        "@algolia/autocomplete-preset-algolia": "1.8.2",
+        "typesense": "^1.4.0-3",
+        "typesense-docsearch-css": "^0.4.0",
+        "typesense-instantsearch-adapter": "^2.4.2-1"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typesense-instantsearch-adapter": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/typesense-instantsearch-adapter/-/typesense-instantsearch-adapter-2.6.0.tgz",
+      "integrity": "sha512-Z9+L5ba/xodoI3urhyS4rKFQiG98dClhOgUfpNj8oP+w5trqBhqwbJLPPScXwzlmCJWUULPQ5786anGjGMNuxQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "typesense": "^1.5.3"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "^7.17.2"
+      }
+    },
+    "node_modules/typesense/node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
     "node_modules/ua-parser-js": {
-      "version": "0.7.31",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
-      "integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==",
+      "version": "0.7.35",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
+      "integrity": "sha512-veRf7dawaj9xaWEu9HoTVn5Pggtc/qj+kqTOFvNiN1l0YdxwC1kvel57UCjThjGa3BHBihE8/UJAHI+uQHmd/g==",
       "funding": [
         {
           "type": "opencollective",
@@ -12021,9 +12448,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.7.tgz",
-      "integrity": "sha512-iN/XYesmZ2RmmWAiI4Z5rq0YqSiv0brj9Ce9CfhNE4xIW2h+MFxcgkxIzZ+ShkFPUkjU3gQ+3oypadD3RAMtrg==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
+      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
       "funding": [
         {
           "type": "opencollective",
@@ -12032,6 +12459,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
@@ -12039,7 +12470,7 @@
         "picocolors": "^1.0.0"
       },
       "bin": {
-        "browserslist-lint": "cli.js"
+        "update-browserslist-db": "cli.js"
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
@@ -12293,6 +12724,14 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -13100,95 +13539,95 @@
   },
   "dependencies": {
     "@algolia/autocomplete-core": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.1.tgz",
-      "integrity": "sha512-eiZw+fxMzNQn01S8dA/hcCpoWCOCwcIIEUtHHdzN5TGB3IpzLbuhqFeTfh2OUhhgkE8Uo17+wH+QJ/wYyQmmzg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.8.2.tgz",
+      "integrity": "sha512-mTeshsyFhAqw/ebqNsQpMtbnjr+qVOSKXArEj4K0d7sqc8It1XD0gkASwecm9mF/jlOQ4Z9RNg1HbdA8JPdRwQ==",
       "requires": {
-        "@algolia/autocomplete-shared": "1.7.1"
+        "@algolia/autocomplete-shared": "1.8.2"
       }
     },
     "@algolia/autocomplete-preset-algolia": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.1.tgz",
-      "integrity": "sha512-pJwmIxeJCymU1M6cGujnaIYcY3QPOVYZOXhFkWVM7IxKzy272BwCvMFMyc5NpG/QmiObBxjo7myd060OeTNJXg==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.8.2.tgz",
+      "integrity": "sha512-J0oTx4me6ZM9kIKPuL3lyU3aB8DEvpVvR6xWmHVROx5rOYJGQcZsdG4ozxwcOyiiu3qxMkIbzntnV1S1VWD8yA==",
       "requires": {
-        "@algolia/autocomplete-shared": "1.7.1"
+        "@algolia/autocomplete-shared": "1.8.2"
       }
     },
     "@algolia/autocomplete-shared": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.1.tgz",
-      "integrity": "sha512-eTmGVqY3GeyBTT8IWiB2K5EuURAqhnumfktAEoHxfDY2o7vg2rSnO16ZtIG0fMgt3py28Vwgq42/bVEuaQV7pg=="
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.8.2.tgz",
+      "integrity": "sha512-b6Z/X4MczChMcfhk6kfRmBzPgjoPzuS9KGR4AFsiLulLNRAAqhP+xZTKtMnZGhLuc61I20d5WqlId02AZvcO6g=="
     },
     "@algolia/cache-browser-local-storage": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.14.2.tgz",
-      "integrity": "sha512-FRweBkK/ywO+GKYfAWbrepewQsPTIEirhi1BdykX9mxvBPtGNKccYAxvGdDCumU1jL4r3cayio4psfzKMejBlA==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.17.0.tgz",
+      "integrity": "sha512-myRSRZDIMYB8uCkO+lb40YKiYHi0fjpWRtJpR/dgkaiBlSD0plRyB6lLOh1XIfmMcSeBOqDE7y9m8xZMrXYfyQ==",
       "requires": {
-        "@algolia/cache-common": "4.14.2"
+        "@algolia/cache-common": "4.17.0"
       }
     },
     "@algolia/cache-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.14.2.tgz",
-      "integrity": "sha512-SbvAlG9VqNanCErr44q6lEKD2qoK4XtFNx9Qn8FK26ePCI8I9yU7pYB+eM/cZdS9SzQCRJBbHUumVr4bsQ4uxg=="
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.17.0.tgz",
+      "integrity": "sha512-g8mXzkrcUBIPZaulAuqE7xyHhLAYAcF2xSch7d9dABheybaU3U91LjBX6eJTEB7XVhEsgK4Smi27vWtAJRhIKQ=="
     },
     "@algolia/cache-in-memory": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.14.2.tgz",
-      "integrity": "sha512-HrOukWoop9XB/VFojPv1R5SVXowgI56T9pmezd/djh2JnVN/vXswhXV51RKy4nCpqxyHt/aGFSq2qkDvj6KiuQ==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.17.0.tgz",
+      "integrity": "sha512-PT32ciC/xI8z919d0oknWVu3kMfTlhQn3MKxDln3pkn+yA7F7xrxSALysxquv+MhFfNAcrtQ/oVvQVBAQSHtdw==",
       "requires": {
-        "@algolia/cache-common": "4.14.2"
+        "@algolia/cache-common": "4.17.0"
       }
     },
     "@algolia/client-account": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.14.2.tgz",
-      "integrity": "sha512-WHtriQqGyibbb/Rx71YY43T0cXqyelEU0lB2QMBRXvD2X0iyeGl4qMxocgEIcbHyK7uqE7hKgjT8aBrHqhgc1w==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.17.0.tgz",
+      "integrity": "sha512-sSEHx9GA6m7wrlsSMNBGfyzlIfDT2fkz2u7jqfCCd6JEEwmxt8emGmxAU/0qBfbhRSuGvzojoLJlr83BSZAKjA==",
       "requires": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/client-search": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/client-common": "4.17.0",
+        "@algolia/client-search": "4.17.0",
+        "@algolia/transporter": "4.17.0"
       }
     },
     "@algolia/client-analytics": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.14.2.tgz",
-      "integrity": "sha512-yBvBv2mw+HX5a+aeR0dkvUbFZsiC4FKSnfqk9rrfX+QrlNOKEhCG0tJzjiOggRW4EcNqRmaTULIYvIzQVL2KYQ==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.17.0.tgz",
+      "integrity": "sha512-84ooP8QA3mQ958hQ9wozk7hFUbAO+81CX1CjAuerxBqjKIInh1fOhXKTaku05O/GHBvcfExpPLIQuSuLYziBXQ==",
       "requires": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/client-search": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/client-common": "4.17.0",
+        "@algolia/client-search": "4.17.0",
+        "@algolia/requester-common": "4.17.0",
+        "@algolia/transporter": "4.17.0"
       }
     },
     "@algolia/client-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.14.2.tgz",
-      "integrity": "sha512-43o4fslNLcktgtDMVaT5XwlzsDPzlqvqesRi4MjQz2x4/Sxm7zYg5LRYFol1BIhG6EwxKvSUq8HcC/KxJu3J0Q==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.17.0.tgz",
+      "integrity": "sha512-jHMks0ZFicf8nRDn6ma8DNNsdwGgP/NKiAAL9z6rS7CymJ7L0+QqTJl3rYxRW7TmBhsUH40wqzmrG6aMIN/DrQ==",
       "requires": {
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/requester-common": "4.17.0",
+        "@algolia/transporter": "4.17.0"
       }
     },
     "@algolia/client-personalization": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.14.2.tgz",
-      "integrity": "sha512-ACCoLi0cL8CBZ1W/2juehSltrw2iqsQBnfiu/Rbl9W2yE6o2ZUb97+sqN/jBqYNQBS+o0ekTMKNkQjHHAcEXNw==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.17.0.tgz",
+      "integrity": "sha512-RMzN4dZLIta1YuwT7QC9o+OeGz2cU6eTOlGNE/6RcUBLOU3l9tkCOdln5dPE2jp8GZXPl2yk54b2nSs1+pAjqw==",
       "requires": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/client-common": "4.17.0",
+        "@algolia/requester-common": "4.17.0",
+        "@algolia/transporter": "4.17.0"
       }
     },
     "@algolia/client-search": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.14.2.tgz",
-      "integrity": "sha512-L5zScdOmcZ6NGiVbLKTvP02UbxZ0njd5Vq9nJAmPFtjffUSOGEp11BmD2oMJ5QvARgx2XbX4KzTTNS5ECYIMWw==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.17.0.tgz",
+      "integrity": "sha512-x4P2wKrrRIXszT8gb7eWsMHNNHAJs0wE7/uqbufm4tZenAp+hwU/hq5KVsY50v+PfwM0LcDwwn/1DroujsTFoA==",
       "requires": {
-        "@algolia/client-common": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/client-common": "4.17.0",
+        "@algolia/requester-common": "4.17.0",
+        "@algolia/transporter": "4.17.0"
       }
     },
     "@algolia/events": {
@@ -13197,47 +13636,47 @@
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
     "@algolia/logger-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.14.2.tgz",
-      "integrity": "sha512-/JGlYvdV++IcMHBnVFsqEisTiOeEr6cUJtpjz8zc0A9c31JrtLm318Njc72p14Pnkw3A/5lHHh+QxpJ6WFTmsA=="
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.17.0.tgz",
+      "integrity": "sha512-DGuoZqpTmIKJFDeyAJ7M8E/LOenIjWiOsg1XJ1OqAU/eofp49JfqXxbfgctlVZVmDABIyOz8LqEoJ6ZP4DTyvw=="
     },
     "@algolia/logger-console": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.14.2.tgz",
-      "integrity": "sha512-8S2PlpdshbkwlLCSAB5f8c91xyc84VM9Ar9EdfE9UmX+NrKNYnWR1maXXVDQQoto07G1Ol/tYFnFVhUZq0xV/g==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.17.0.tgz",
+      "integrity": "sha512-zMPvugQV/gbXUvWBCzihw6m7oxIKp48w37QBIUu/XqQQfxhjoOE9xyfJr1KldUt5FrYOKZJVsJaEjTsu+bIgQg==",
       "requires": {
-        "@algolia/logger-common": "4.14.2"
+        "@algolia/logger-common": "4.17.0"
       }
     },
     "@algolia/requester-browser-xhr": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.14.2.tgz",
-      "integrity": "sha512-CEh//xYz/WfxHFh7pcMjQNWgpl4wFB85lUMRyVwaDPibNzQRVcV33YS+63fShFWc2+42YEipFGH2iPzlpszmDw==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.17.0.tgz",
+      "integrity": "sha512-aSOX/smauyTkP21Pf52pJ1O2LmNFJ5iHRIzEeTh0mwBeADO4GdG94cAWDILFA9rNblq/nK3EDh3+UyHHjplZ1A==",
       "requires": {
-        "@algolia/requester-common": "4.14.2"
+        "@algolia/requester-common": "4.17.0"
       }
     },
     "@algolia/requester-common": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.14.2.tgz",
-      "integrity": "sha512-73YQsBOKa5fvVV3My7iZHu1sUqmjjfs9TteFWwPwDmnad7T0VTCopttcsM3OjLxZFtBnX61Xxl2T2gmG2O4ehg=="
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.17.0.tgz",
+      "integrity": "sha512-XJjmWFEUlHu0ijvcHBoixuXfEoiRUdyzQM6YwTuB8usJNIgShua8ouFlRWF8iCeag0vZZiUm4S2WCVBPkdxFgg=="
     },
     "@algolia/requester-node-http": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.14.2.tgz",
-      "integrity": "sha512-oDbb02kd1o5GTEld4pETlPZLY0e+gOSWjWMJHWTgDXbv9rm/o2cF7japO6Vj1ENnrqWvLBmW1OzV9g6FUFhFXg==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.17.0.tgz",
+      "integrity": "sha512-bpb/wDA1aC6WxxM8v7TsFspB7yBN3nqCGs2H1OADolQR/hiAIjAxusbuMxVbRFOdaUvAIqioIIkWvZdpYNIn8w==",
       "requires": {
-        "@algolia/requester-common": "4.14.2"
+        "@algolia/requester-common": "4.17.0"
       }
     },
     "@algolia/transporter": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.14.2.tgz",
-      "integrity": "sha512-t89dfQb2T9MFQHidjHcfhh6iGMNwvuKUvojAj+JsrHAGbuSy7yE4BylhLX6R0Q1xYRoC4Vvv+O5qIw/LdnQfsQ==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.17.0.tgz",
+      "integrity": "sha512-6xL6H6fe+Fi0AEP3ziSgC+G04RK37iRb4uUUqVAH9WPYFI8g+LYFq6iv5HS8Cbuc5TTut+Bwj6G+dh/asdb9uA==",
       "requires": {
-        "@algolia/cache-common": "4.14.2",
-        "@algolia/logger-common": "4.14.2",
-        "@algolia/requester-common": "4.14.2"
+        "@algolia/cache-common": "4.17.0",
+        "@algolia/logger-common": "4.17.0",
+        "@algolia/requester-common": "4.17.0"
       }
     },
     "@ampproject/remapping": {
@@ -14397,11 +14836,11 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.19.0.tgz",
-      "integrity": "sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
+      "integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       }
     },
     "@babel/runtime-corejs3": {
@@ -14457,25 +14896,25 @@
       "optional": true
     },
     "@docsearch/css": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.2.1.tgz",
-      "integrity": "sha512-gaP6TxxwQC+K8D6TRx5WULUWKrcbzECOPA2KCVMuI+6C7dNiGUk5yXXzVhc5sld79XKYLnO9DRTI4mjXDYkh+g=="
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.4.tgz",
+      "integrity": "sha512-vDwCDoVXDgopw/hvr0zEADew2wWaGP8Qq0Bxhgii1Ewz2t4fQeyJwIRN/mWADeLFYPVkpz8TpEbxya/i6Tm0WA=="
     },
     "@docsearch/react": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.2.1.tgz",
-      "integrity": "sha512-EzTQ/y82s14IQC5XVestiK/kFFMe2aagoYFuTAIfIb/e+4FU7kSMKonRtLwsCiLQHmjvNQq+HO+33giJ5YVtaQ==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.4.tgz",
+      "integrity": "sha512-aeOf1WC5zMzBEi2SI6WWznOmIo9rnpN4p7a3zHXxowVciqlI4HsZGtOR9nFOufLeolv7HibwLlaM0oyUqJxasw==",
       "requires": {
-        "@algolia/autocomplete-core": "1.7.1",
-        "@algolia/autocomplete-preset-algolia": "1.7.1",
-        "@docsearch/css": "3.2.1",
+        "@algolia/autocomplete-core": "1.8.2",
+        "@algolia/autocomplete-preset-algolia": "1.8.2",
+        "@docsearch/css": "3.3.4",
         "algoliasearch": "^4.0.0"
       }
     },
     "@docusaurus/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.4.1.tgz",
+      "integrity": "sha512-SNsY7PshK3Ri7vtsLXVeAJGS50nJN3RgF836zkyUfAD01Fq+sAk5EwWgLw+nnm5KVNGDu7PRR2kRGDsWvqpo0g==",
       "requires": {
         "@babel/core": "^7.18.6",
         "@babel/generator": "^7.18.7",
@@ -14487,13 +14926,13 @@
         "@babel/runtime": "^7.18.6",
         "@babel/runtime-corejs3": "^7.18.6",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
+        "@docusaurus/cssnano-preset": "2.4.1",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/mdx-loader": "2.4.1",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-common": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.2.1",
         "autoprefixer": "^10.4.7",
@@ -14514,7 +14953,7 @@
         "del": "^6.1.1",
         "detect-port": "^1.3.0",
         "escape-html": "^1.0.3",
-        "eta": "^1.12.3",
+        "eta": "^2.0.0",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.1.0",
         "html-minifier-terser": "^6.1.0",
@@ -14551,9 +14990,9 @@
       }
     },
     "@docusaurus/cssnano-preset": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
-      "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.4.1.tgz",
+      "integrity": "sha512-ka+vqXwtcW1NbXxWsh6yA1Ckii1klY9E53cJ4O9J09nkMBgrNX3iEFED1fWdv8wf4mJjvGi5RLZ2p9hJNjsLyQ==",
       "requires": {
         "cssnano-preset-advanced": "^5.3.8",
         "postcss": "^8.4.14",
@@ -14562,23 +15001,23 @@
       }
     },
     "@docusaurus/logger": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.1.0.tgz",
-      "integrity": "sha512-uuJx2T6hDBg82joFeyobywPjSOIfeq05GfyKGHThVoXuXsu1KAzMDYcjoDxarb9CoHCI/Dor8R2MoL6zII8x1Q==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.4.1.tgz",
+      "integrity": "sha512-5h5ysIIWYIDHyTVd8BjheZmQZmEgWDR54aQ1BX9pjFfpyzFo5puKXKYrYJXbjEHGyVhEzmB9UXwbxGfaZhOjcg==",
       "requires": {
         "chalk": "^4.1.2",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/mdx-loader": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.1.0.tgz",
-      "integrity": "sha512-i97hi7hbQjsD3/8OSFhLy7dbKGH8ryjEzOfyhQIn2CFBYOY3ko0vMVEf3IY9nD3Ld7amYzsZ8153RPkcnXA+Lg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.4.1.tgz",
+      "integrity": "sha512-4KhUhEavteIAmbBj7LVFnrVYDiU51H5YWW1zY6SmBSte/YLhDutztLTBE0PQl1Grux1jzUJeaSvAzHpTn6JJDQ==",
       "requires": {
         "@babel/parser": "^7.18.8",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -14595,12 +15034,12 @@
       }
     },
     "@docusaurus/module-type-aliases": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.1.0.tgz",
-      "integrity": "sha512-Z8WZaK5cis3xEtyfOT817u9xgGUauT0PuuVo85ysnFRX8n7qLN1lTPCkC+aCmFm/UcV8h/W5T4NtIsst94UntQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.4.1.tgz",
+      "integrity": "sha512-gLBuIFM8Dp2XOCWffUDSjtxY7jQgKvYujt7Mx5s4FCTfoL5dN1EVbnrn+O2Wvh8b0a77D57qoIDY7ghgmatR1A==",
       "requires": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.1.0",
+        "@docusaurus/types": "2.4.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -14610,17 +15049,17 @@
       }
     },
     "@docusaurus/plugin-content-blog": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.1.0.tgz",
-      "integrity": "sha512-xEp6jlu92HMNUmyRBEeJ4mCW1s77aAEQO4Keez94cUY/Ap7G/r0Awa6xSLff7HL0Fjg8KK1bEbDy7q9voIavdg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.4.1.tgz",
+      "integrity": "sha512-E2i7Knz5YIbE1XELI6RlTnZnGgS52cUO4BlCiCUCvQHbR+s1xeIWz4C6BtaVnlug0Ccz7nFSksfwDpVlkujg5Q==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/mdx-loader": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-common": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^10.1.0",
@@ -14633,17 +15072,17 @@
       }
     },
     "@docusaurus/plugin-content-docs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.1.0.tgz",
-      "integrity": "sha512-Rup5pqXrXlKGIC4VgwvioIhGWF7E/NNSlxv+JAxRYpik8VKlWsk9ysrdHIlpX+KJUCO9irnY21kQh2814mlp/Q==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.4.1.tgz",
+      "integrity": "sha512-Lo7lSIcpswa2Kv4HEeUcGYqaasMUQNpjTXpV0N8G6jXgZaQurqp7E8NGYeGbDXnb48czmHWbzDL4S3+BbK0VzA==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/mdx-loader": "2.4.1",
+        "@docusaurus/module-type-aliases": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "@types/react-router-config": "^5.0.6",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.1.0",
@@ -14656,88 +15095,100 @@
       }
     },
     "@docusaurus/plugin-content-pages": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.1.0.tgz",
-      "integrity": "sha512-SwZdDZRlObHNKXTnFo7W2aF6U5ZqNVI55Nw2GCBryL7oKQSLeI0lsrMlMXdzn+fS7OuBTd3MJBO1T4Zpz0i/+g==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.4.1.tgz",
+      "integrity": "sha512-/UjuH/76KLaUlL+o1OvyORynv6FURzjurSjvn2lbWTFc4tpYY2qLYTlKpTCBVPhlLUQsfyFnshEJDLmPneq2oA==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/mdx-loader": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
       }
     },
     "@docusaurus/plugin-debug": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.1.0.tgz",
-      "integrity": "sha512-8wsDq3OIfiy6440KLlp/qT5uk+WRHQXIXklNHEeZcar+Of0TZxCNe2FBpv+bzb/0qcdP45ia5i5WmR5OjN6DPw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.4.1.tgz",
+      "integrity": "sha512-7Yu9UPzRShlrH/G8btOpR0e6INFZr0EegWplMjOqelIwAcx3PKyR8mgPTxGTxcqiYj6hxSCRN0D8R7YrzImwNA==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-google-analytics": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.1.0.tgz",
-      "integrity": "sha512-4cgeqIly/wcFVbbWP03y1QJJBgH8W+Bv6AVbWnsXNOZa1yB3AO6hf3ZdeQH9x20v9T2pREogVgAH0rSoVnNsgg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.4.1.tgz",
+      "integrity": "sha512-dyZJdJiCoL+rcfnm0RPkLt/o732HvLiEwmtoNzOoz9MSZz117UH2J6U2vUDtzUzwtFLIf32KkeyzisbwUCgcaQ==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-google-gtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.1.0.tgz",
-      "integrity": "sha512-/3aDlv2dMoCeiX2e+DTGvvrdTA+v3cKQV3DbmfsF4ENhvc5nKV23nth04Z3Vq0Ci1ui6Sn80TkhGk/tiCMW2AA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.4.1.tgz",
+      "integrity": "sha512-mKIefK+2kGTQBYvloNEKtDmnRD7bxHLsBcxgnbt4oZwzi2nxCGjPX6+9SQO2KCN5HZbNrYmGo5GJfMgoRvy6uA==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@docusaurus/plugin-google-tag-manager": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-2.4.1.tgz",
+      "integrity": "sha512-Zg4Ii9CMOLfpeV2nG74lVTWNtisFaH9QNtEw48R5QE1KIwDBdTVaiSA18G1EujZjrzJJzXN79VhINSbOJO/r3g==",
+      "requires": {
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/plugin-sitemap": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.1.0.tgz",
-      "integrity": "sha512-2Y6Br8drlrZ/jN9MwMBl0aoi9GAjpfyfMBYpaQZXimbK+e9VjYnujXlvQ4SxtM60ASDgtHIAzfVFBkSR/MwRUw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.4.1.tgz",
+      "integrity": "sha512-lZx+ijt/+atQ3FVE8FOHV/+X3kuok688OydDXrqKRJyXBJZKgGjA2Qa8RjQ4f27V2woaXhtnyrdPop/+OjVMRg==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-common": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/preset-classic": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.1.0.tgz",
-      "integrity": "sha512-NQMnaq974K4BcSMXFSJBQ5itniw6RSyW+VT+6i90kGZzTwiuKZmsp0r9lC6BYAvvVMQUNJQwrETmlu7y2XKW7w==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.4.1.tgz",
+      "integrity": "sha512-P4//+I4zDqQJ+UDgoFrjIFaQ1MeS9UD1cvxVQaI6O7iBmiHQm0MGROP1TbE7HlxlDPXFJjZUK3x3cAoK63smGQ==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/plugin-debug": "2.1.0",
-        "@docusaurus/plugin-google-analytics": "2.1.0",
-        "@docusaurus/plugin-google-gtag": "2.1.0",
-        "@docusaurus/plugin-sitemap": "2.1.0",
-        "@docusaurus/theme-classic": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-search-algolia": "2.1.0",
-        "@docusaurus/types": "2.1.0"
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/plugin-content-blog": "2.4.1",
+        "@docusaurus/plugin-content-docs": "2.4.1",
+        "@docusaurus/plugin-content-pages": "2.4.1",
+        "@docusaurus/plugin-debug": "2.4.1",
+        "@docusaurus/plugin-google-analytics": "2.4.1",
+        "@docusaurus/plugin-google-gtag": "2.4.1",
+        "@docusaurus/plugin-google-tag-manager": "2.4.1",
+        "@docusaurus/plugin-sitemap": "2.4.1",
+        "@docusaurus/theme-classic": "2.4.1",
+        "@docusaurus/theme-common": "2.4.1",
+        "@docusaurus/theme-search-algolia": "2.4.1",
+        "@docusaurus/types": "2.4.1"
       }
     },
     "@docusaurus/react-loadable": {
@@ -14750,26 +15201,26 @@
       }
     },
     "@docusaurus/theme-classic": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.1.0.tgz",
-      "integrity": "sha512-xn8ZfNMsf7gaSy9+ClFnUu71o7oKgMo5noYSS1hy3svNifRTkrBp6+MReLDsmIaj3mLf2e7+JCBYKBFbaGzQng==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.4.1.tgz",
+      "integrity": "sha512-Rz0wKUa+LTW1PLXmwnf8mn85EBzaGSt6qamqtmnh9Hflkc+EqiYMhtUJeLdV+wsgYq4aG0ANc+bpUDpsUhdnwg==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-translations": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/mdx-loader": "2.4.1",
+        "@docusaurus/module-type-aliases": "2.4.1",
+        "@docusaurus/plugin-content-blog": "2.4.1",
+        "@docusaurus/plugin-content-docs": "2.4.1",
+        "@docusaurus/plugin-content-pages": "2.4.1",
+        "@docusaurus/theme-common": "2.4.1",
+        "@docusaurus/theme-translations": "2.4.1",
+        "@docusaurus/types": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-common": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "copy-text-to-clipboard": "^3.0.1",
-        "infima": "0.2.0-alpha.42",
+        "infima": "0.2.0-alpha.43",
         "lodash": "^4.17.21",
         "nprogress": "^0.2.0",
         "postcss": "^8.4.14",
@@ -14782,16 +15233,17 @@
       }
     },
     "@docusaurus/theme-common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.1.0.tgz",
-      "integrity": "sha512-vT1otpVPbKux90YpZUnvknsn5zvpLf+AW1W0EDcpE9up4cDrPqfsh0QoxGHFJnobE2/qftsBFC19BneN4BH8Ag==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.4.1.tgz",
+      "integrity": "sha512-G7Zau1W5rQTaFFB3x3soQoZpkgMbl/SYNG8PfMFIjKa3M3q8n0m/GRf5/H/e5BqOvt8c+ZWIXGCiz+kUCSHovA==",
       "requires": {
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/mdx-loader": "2.4.1",
+        "@docusaurus/module-type-aliases": "2.4.1",
+        "@docusaurus/plugin-content-blog": "2.4.1",
+        "@docusaurus/plugin-content-docs": "2.4.1",
+        "@docusaurus/plugin-content-pages": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-common": "2.4.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -14799,26 +15251,27 @@
         "parse-numeric-range": "^1.3.0",
         "prism-react-renderer": "^1.3.5",
         "tslib": "^2.4.0",
+        "use-sync-external-store": "^1.2.0",
         "utility-types": "^3.10.0"
       }
     },
     "@docusaurus/theme-search-algolia": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.1.0.tgz",
-      "integrity": "sha512-rNBvi35VvENhucslEeVPOtbAzBdZY/9j55gdsweGV5bYoAXy4mHB6zTGjealcB4pJ6lJY4a5g75fXXMOlUqPfg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.4.1.tgz",
+      "integrity": "sha512-6BcqW2lnLhZCXuMAvPRezFs1DpmEKzXFKlYjruuas+Xy3AQeFzDJKTJFIm49N77WFCTyxff8d3E4Q9pi/+5McQ==",
       "requires": {
         "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-translations": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.4.1",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/plugin-content-docs": "2.4.1",
+        "@docusaurus/theme-common": "2.4.1",
+        "@docusaurus/theme-translations": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
+        "@docusaurus/utils-validation": "2.4.1",
         "algoliasearch": "^4.13.1",
         "algoliasearch-helper": "^3.10.0",
         "clsx": "^1.2.1",
-        "eta": "^1.12.3",
+        "eta": "^2.0.0",
         "fs-extra": "^10.1.0",
         "lodash": "^4.17.21",
         "tslib": "^2.4.0",
@@ -14826,18 +15279,18 @@
       }
     },
     "@docusaurus/theme-translations": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.1.0.tgz",
-      "integrity": "sha512-07n2akf2nqWvtJeMy3A+7oSGMuu5F673AovXVwY0aGAux1afzGCiqIFlYW3EP0CujvDJAEFSQi/Tetfh+95JNg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.4.1.tgz",
+      "integrity": "sha512-T1RAGP+f86CA1kfE8ejZ3T3pUU3XcyvrGMfC/zxCtc2BsnoexuNI9Vk2CmuKCb+Tacvhxjv5unhxXce0+NKyvA==",
       "requires": {
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.1.0.tgz",
-      "integrity": "sha512-BS1ebpJZnGG6esKqsjtEC9U9qSaPylPwlO7cQ1GaIE7J/kMZI3FITnNn0otXXu7c7ZTqhb6+8dOrG6fZn6fqzQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.4.1.tgz",
+      "integrity": "sha512-0R+cbhpMkhbRXX138UOc/2XZFF8hiZa6ooZAEEJFp5scytzCw4tC1gChMFXrpa3d2tYE6AX8IrOEpSonLmfQuQ==",
       "requires": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
@@ -14850,12 +15303,13 @@
       }
     },
     "@docusaurus/utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.1.0.tgz",
-      "integrity": "sha512-fPvrfmAuC54n8MjZuG4IysaMdmvN5A/qr7iFLbSGSyDrsbP4fnui6KdZZIa/YOLIPLec8vjZ8RIITJqF18mx4A==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.4.1.tgz",
+      "integrity": "sha512-1lvEZdAQhKNht9aPXPoh69eeKnV0/62ROhQeFKKxmzd0zkcuE/Oc5Gpnt00y/f5bIsmOsYMY7Pqfm/5rteT5GA==",
       "requires": {
-        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/logger": "2.4.1",
         "@svgr/webpack": "^6.2.1",
+        "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.1.0",
         "github-slugger": "^1.4.0",
@@ -14872,20 +15326,20 @@
       }
     },
     "@docusaurus/utils-common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.1.0.tgz",
-      "integrity": "sha512-F2vgmt4yRFgRQR2vyEFGTWeyAdmgKbtmu3sjHObF0tjjx/pN0Iw/c6eCopaH34E6tc9nO0nvp01pwW+/86d1fg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.4.1.tgz",
+      "integrity": "sha512-bCVGdZU+z/qVcIiEQdyx0K13OC5mYwxhSuDUR95oFbKVuXYRrTVrwZIqQljuo1fyJvFTKHiL9L9skQOPokuFNQ==",
       "requires": {
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/utils-validation": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.1.0.tgz",
-      "integrity": "sha512-AMJzWYKL3b7FLltKtDXNLO9Y649V2BXvrnRdnW2AA+PpBnYV78zKLSCz135cuWwRj1ajNtP4onbXdlnyvCijGQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.4.1.tgz",
+      "integrity": "sha512-unII3hlJlDwZ3w8U+pMO3Lx3RhI4YEbY3YNsQj4yzrkZzlpqZOLuAiZK2JyULnD+TKbceKU0WyWkQXtYbLNDFA==",
       "requires": {
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/logger": "2.4.1",
+        "@docusaurus/utils": "2.4.1",
         "joi": "^17.6.0",
         "js-yaml": "^4.1.0",
         "tslib": "^2.4.0"
@@ -15868,30 +16322,30 @@
       "requires": {}
     },
     "algoliasearch": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.14.2.tgz",
-      "integrity": "sha512-ngbEQonGEmf8dyEh5f+uOIihv4176dgbuOZspiuhmTTBRBuzWu3KCGHre6uHj5YyuC7pNvQGzB6ZNJyZi0z+Sg==",
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.17.0.tgz",
+      "integrity": "sha512-JMRh2Mw6sEnVMiz6+APsi7lx9a2jiDFF+WUtANaUVCv6uSU9UOLdo5h9K3pdP6frRRybaM2fX8b1u0nqICS9aA==",
       "requires": {
-        "@algolia/cache-browser-local-storage": "4.14.2",
-        "@algolia/cache-common": "4.14.2",
-        "@algolia/cache-in-memory": "4.14.2",
-        "@algolia/client-account": "4.14.2",
-        "@algolia/client-analytics": "4.14.2",
-        "@algolia/client-common": "4.14.2",
-        "@algolia/client-personalization": "4.14.2",
-        "@algolia/client-search": "4.14.2",
-        "@algolia/logger-common": "4.14.2",
-        "@algolia/logger-console": "4.14.2",
-        "@algolia/requester-browser-xhr": "4.14.2",
-        "@algolia/requester-common": "4.14.2",
-        "@algolia/requester-node-http": "4.14.2",
-        "@algolia/transporter": "4.14.2"
+        "@algolia/cache-browser-local-storage": "4.17.0",
+        "@algolia/cache-common": "4.17.0",
+        "@algolia/cache-in-memory": "4.17.0",
+        "@algolia/client-account": "4.17.0",
+        "@algolia/client-analytics": "4.17.0",
+        "@algolia/client-common": "4.17.0",
+        "@algolia/client-personalization": "4.17.0",
+        "@algolia/client-search": "4.17.0",
+        "@algolia/logger-common": "4.17.0",
+        "@algolia/logger-console": "4.17.0",
+        "@algolia/requester-browser-xhr": "4.17.0",
+        "@algolia/requester-common": "4.17.0",
+        "@algolia/requester-node-http": "4.17.0",
+        "@algolia/transporter": "4.17.0"
       }
     },
     "algoliasearch-helper": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.11.1.tgz",
-      "integrity": "sha512-mvsPN3eK4E0bZG0/WlWJjeqe/bUD2KOEVOl0GyL/TGXn6wcpZU8NOuztGHCUKXkyg5gq6YzUakVTmnmSSO5Yiw==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.13.0.tgz",
+      "integrity": "sha512-kV3c1jMQCvkARtGsSDvAwuht4PAMSsQILqPiH4WFiARoa3jXJ/r1TQoBWAjWyWF48rsNYCv7kzxgB4LTxrvvuw==",
       "requires": {
         "@algolia/events": "^4.0.1"
       }
@@ -15984,12 +16438,12 @@
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "autoprefixer": {
-      "version": "10.4.9",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.9.tgz",
-      "integrity": "sha512-Uu67eduPEmOeA0vyJby5ghu1AAELCCNSsLAjK+lz6kYzNM5sqnBO36MqfsjhPjQF/BaJM5U/UuFYyl7PavY/wQ==",
+      "version": "10.4.14",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
+      "integrity": "sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==",
       "requires": {
-        "browserslist": "^4.21.3",
-        "caniuse-lite": "^1.0.30001394",
+        "browserslist": "^4.21.5",
+        "caniuse-lite": "^1.0.30001464",
         "fraction.js": "^4.2.0",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -16211,14 +16665,14 @@
       "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
     },
     "browserslist": {
-      "version": "4.21.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
-      "integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
+      "version": "4.21.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
+      "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
       "requires": {
-        "caniuse-lite": "^1.0.30001370",
-        "electron-to-chromium": "^1.4.202",
-        "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.5"
+        "caniuse-lite": "^1.0.30001449",
+        "electron-to-chromium": "^1.4.284",
+        "node-releases": "^2.0.8",
+        "update-browserslist-db": "^1.0.10"
       }
     },
     "buffer-from": {
@@ -16310,9 +16764,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001397",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001397.tgz",
-      "integrity": "sha512-SW9N2TbCdLf0eiNDRrrQXx2sOkaakNZbCjgNpPyMJJbiOrU5QzMIrXOVMRM1myBXTD5iTkdrtU/EguCrBocHlA=="
+      "version": "1.0.30001487",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001487.tgz",
+      "integrity": "sha512-83564Z3yWGqXsh2vaH/mhXfEM0wX+NlBCm1jYHOb97TrTWJEmPTccZgeLTPBUUb0PNVo+oomb7wkimZBIERClA=="
     },
     "ccount": {
       "version": "1.1.0",
@@ -16619,9 +17073,9 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "copy-text-to-clipboard": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.0.1.tgz",
-      "integrity": "sha512-rvVsHrpFcL4F2P8ihsoLdFHmd404+CMg71S756oRSeQgqk51U3kicGdnvfkrxva0xXH92SjGS62B0XIJsbh+9Q=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.1.0.tgz",
+      "integrity": "sha512-PFM6BnjLnOON/lB3ta/Jg7Ywsv+l9kQGD4TWDCSlRBGmqnnTM5MrDkhAFgw+8HZt0wW6Q2BBE4cmy9sq+s9Qng=="
     },
     "copy-webpack-plugin": {
       "version": "11.0.0",
@@ -16734,11 +17188,11 @@
       }
     },
     "cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.6.tgz",
+      "integrity": "sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==",
       "requires": {
-        "node-fetch": "2.6.7"
+        "node-fetch": "^2.6.11"
       }
     },
     "cross-spawn": {
@@ -16869,12 +17323,12 @@
       }
     },
     "cssnano-preset-advanced": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.3.8.tgz",
-      "integrity": "sha512-xUlLLnEB1LjpEik+zgRNlk8Y/koBPPtONZjp7JKbXigeAmCrFvq9H0pXW5jJV45bQWAlmJ0sKy+IMr0XxLYQZg==",
+      "version": "5.3.10",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.3.10.tgz",
+      "integrity": "sha512-fnYJyCS9jgMU+cmHO1rPSPf9axbQyD7iUhLO5Df6O4G+fKIOMps+ZbU0PdGFejFBBZ3Pftf18fn1eG7MAPUSWQ==",
       "requires": {
-        "autoprefixer": "^10.3.7",
-        "cssnano-preset-default": "^5.2.12",
+        "autoprefixer": "^10.4.12",
+        "cssnano-preset-default": "^5.2.14",
         "postcss-discard-unused": "^5.1.0",
         "postcss-merge-idents": "^5.1.1",
         "postcss-reduce-idents": "^5.2.0",
@@ -16882,24 +17336,24 @@
       }
     },
     "cssnano-preset-default": {
-      "version": "5.2.12",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.12.tgz",
-      "integrity": "sha512-OyCBTZi+PXgylz9HAA5kHyoYhfGcYdwFmyaJzWnzxuGRtnMw/kR6ilW9XzlzlRAtB6PLT/r+prYgkef7hngFew==",
+      "version": "5.2.14",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.14.tgz",
+      "integrity": "sha512-t0SFesj/ZV2OTylqQVOrFgEh5uanxbO6ZAdeCrNsUQ6fVuXwYTxJPNAGvGTxHbD68ldIJNec7PyYZDBrfDQ+6A==",
       "requires": {
-        "css-declaration-sorter": "^6.3.0",
+        "css-declaration-sorter": "^6.3.1",
         "cssnano-utils": "^3.1.0",
         "postcss-calc": "^8.2.3",
-        "postcss-colormin": "^5.3.0",
-        "postcss-convert-values": "^5.1.2",
+        "postcss-colormin": "^5.3.1",
+        "postcss-convert-values": "^5.1.3",
         "postcss-discard-comments": "^5.1.2",
         "postcss-discard-duplicates": "^5.1.0",
         "postcss-discard-empty": "^5.1.1",
         "postcss-discard-overridden": "^5.1.0",
-        "postcss-merge-longhand": "^5.1.6",
-        "postcss-merge-rules": "^5.1.2",
+        "postcss-merge-longhand": "^5.1.7",
+        "postcss-merge-rules": "^5.1.4",
         "postcss-minify-font-values": "^5.1.0",
         "postcss-minify-gradients": "^5.1.1",
-        "postcss-minify-params": "^5.1.3",
+        "postcss-minify-params": "^5.1.4",
         "postcss-minify-selectors": "^5.2.1",
         "postcss-normalize-charset": "^5.1.0",
         "postcss-normalize-display-values": "^5.1.0",
@@ -16907,11 +17361,11 @@
         "postcss-normalize-repeat-style": "^5.1.1",
         "postcss-normalize-string": "^5.1.0",
         "postcss-normalize-timing-functions": "^5.1.0",
-        "postcss-normalize-unicode": "^5.1.0",
+        "postcss-normalize-unicode": "^5.1.1",
         "postcss-normalize-url": "^5.1.0",
         "postcss-normalize-whitespace": "^5.1.1",
         "postcss-ordered-values": "^5.1.3",
-        "postcss-reduce-initial": "^5.1.0",
+        "postcss-reduce-initial": "^5.1.2",
         "postcss-reduce-transforms": "^5.1.0",
         "postcss-svgo": "^5.1.0",
         "postcss-unique-selectors": "^5.1.1"
@@ -17170,6 +17624,260 @@
         "@leichtgewicht/ip-codec": "^2.0.1"
       }
     },
+    "docusaurus-theme-search-typesense": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/docusaurus-theme-search-typesense/-/docusaurus-theme-search-typesense-0.11.0.tgz",
+      "integrity": "sha512-nIWJVFSN+q2lJmAVkgqC6+XqBEiGorB5c6YDjmFQO28HIDynWJQchDVHgaeB4440Kk6PxrzwraNr+SHyZKVrtw==",
+      "requires": {
+        "@docusaurus/logger": "2.4.0",
+        "@docusaurus/plugin-content-docs": "2.4.0",
+        "@docusaurus/theme-translations": "2.4.0",
+        "@docusaurus/utils": "2.4.0",
+        "@docusaurus/utils-validation": "2.4.0",
+        "algoliasearch-helper": "^3.10.0",
+        "clsx": "^1.2.1",
+        "eta": "^2.0.0",
+        "fs-extra": "^10.1.0",
+        "lodash": "^4.17.21",
+        "tslib": "^2.4.0",
+        "typesense-docsearch-react": "^3.4.0",
+        "typesense-instantsearch-adapter": "^2.6.0",
+        "utility-types": "^3.10.0"
+      },
+      "dependencies": {
+        "@docusaurus/cssnano-preset": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.4.0.tgz",
+          "integrity": "sha512-RmdiA3IpsLgZGXRzqnmTbGv43W4OD44PCo+6Q/aYjEM2V57vKCVqNzuafE94jv0z/PjHoXUrjr69SaRymBKYYw==",
+          "requires": {
+            "cssnano-preset-advanced": "^5.3.8",
+            "postcss": "^8.4.14",
+            "postcss-sort-media-queries": "^4.2.1",
+            "tslib": "^2.4.0"
+          }
+        },
+        "@docusaurus/logger": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.4.0.tgz",
+          "integrity": "sha512-T8+qR4APN+MjcC9yL2Es+xPJ2923S9hpzDmMtdsOcUGLqpCGBbU1vp3AAqDwXtVgFkq+NsEk7sHdVsfLWR/AXw==",
+          "requires": {
+            "chalk": "^4.1.2",
+            "tslib": "^2.4.0"
+          }
+        },
+        "@docusaurus/mdx-loader": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.4.0.tgz",
+          "integrity": "sha512-GWoH4izZKOmFoC+gbI2/y8deH/xKLvzz/T5BsEexBye8EHQlwsA7FMrVa48N063bJBH4FUOiRRXxk5rq9cC36g==",
+          "requires": {
+            "@babel/parser": "^7.18.8",
+            "@babel/traverse": "^7.18.8",
+            "@docusaurus/logger": "2.4.0",
+            "@docusaurus/utils": "2.4.0",
+            "@mdx-js/mdx": "^1.6.22",
+            "escape-html": "^1.0.3",
+            "file-loader": "^6.2.0",
+            "fs-extra": "^10.1.0",
+            "image-size": "^1.0.1",
+            "mdast-util-to-string": "^2.0.0",
+            "remark-emoji": "^2.2.0",
+            "stringify-object": "^3.3.0",
+            "tslib": "^2.4.0",
+            "unified": "^9.2.2",
+            "unist-util-visit": "^2.0.3",
+            "url-loader": "^4.1.1",
+            "webpack": "^5.73.0"
+          }
+        },
+        "@docusaurus/module-type-aliases": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.4.0.tgz",
+          "integrity": "sha512-YEQO2D3UXs72qCn8Cr+RlycSQXVGN9iEUyuHwTuK4/uL/HFomB2FHSU0vSDM23oLd+X/KibQ3Ez6nGjQLqXcHg==",
+          "requires": {
+            "@docusaurus/react-loadable": "5.5.2",
+            "@docusaurus/types": "2.4.0",
+            "@types/history": "^4.7.11",
+            "@types/react": "*",
+            "@types/react-router-config": "*",
+            "@types/react-router-dom": "*",
+            "react-helmet-async": "*",
+            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
+          }
+        },
+        "@docusaurus/plugin-content-docs": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.4.0.tgz",
+          "integrity": "sha512-ic/Z/ZN5Rk/RQo+Io6rUGpToOtNbtPloMR2JcGwC1xT2riMu6zzfSwmBi9tHJgdXH6CB5jG+0dOZZO8QS5tmDg==",
+          "requires": {
+            "@docusaurus/core": "2.4.0",
+            "@docusaurus/logger": "2.4.0",
+            "@docusaurus/mdx-loader": "2.4.0",
+            "@docusaurus/module-type-aliases": "2.4.0",
+            "@docusaurus/types": "2.4.0",
+            "@docusaurus/utils": "2.4.0",
+            "@docusaurus/utils-validation": "2.4.0",
+            "@types/react-router-config": "^5.0.6",
+            "combine-promises": "^1.1.0",
+            "fs-extra": "^10.1.0",
+            "import-fresh": "^3.3.0",
+            "js-yaml": "^4.1.0",
+            "lodash": "^4.17.21",
+            "tslib": "^2.4.0",
+            "utility-types": "^3.10.0",
+            "webpack": "^5.73.0"
+          },
+          "dependencies": {
+            "@docusaurus/core": {
+              "version": "2.4.0",
+              "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.4.0.tgz",
+              "integrity": "sha512-J55/WEoIpRcLf3afO5POHPguVZosKmJEQWKBL+K7TAnfuE7i+Y0NPLlkKtnWCehagGsgTqClfQEexH/UT4kELA==",
+              "requires": {
+                "@babel/core": "^7.18.6",
+                "@babel/generator": "^7.18.7",
+                "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+                "@babel/plugin-transform-runtime": "^7.18.6",
+                "@babel/preset-env": "^7.18.6",
+                "@babel/preset-react": "^7.18.6",
+                "@babel/preset-typescript": "^7.18.6",
+                "@babel/runtime": "^7.18.6",
+                "@babel/runtime-corejs3": "^7.18.6",
+                "@babel/traverse": "^7.18.8",
+                "@docusaurus/cssnano-preset": "2.4.0",
+                "@docusaurus/logger": "2.4.0",
+                "@docusaurus/mdx-loader": "2.4.0",
+                "@docusaurus/react-loadable": "5.5.2",
+                "@docusaurus/utils": "2.4.0",
+                "@docusaurus/utils-common": "2.4.0",
+                "@docusaurus/utils-validation": "2.4.0",
+                "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
+                "@svgr/webpack": "^6.2.1",
+                "autoprefixer": "^10.4.7",
+                "babel-loader": "^8.2.5",
+                "babel-plugin-dynamic-import-node": "^2.3.3",
+                "boxen": "^6.2.1",
+                "chalk": "^4.1.2",
+                "chokidar": "^3.5.3",
+                "clean-css": "^5.3.0",
+                "cli-table3": "^0.6.2",
+                "combine-promises": "^1.1.0",
+                "commander": "^5.1.0",
+                "copy-webpack-plugin": "^11.0.0",
+                "core-js": "^3.23.3",
+                "css-loader": "^6.7.1",
+                "css-minimizer-webpack-plugin": "^4.0.0",
+                "cssnano": "^5.1.12",
+                "del": "^6.1.1",
+                "detect-port": "^1.3.0",
+                "escape-html": "^1.0.3",
+                "eta": "^2.0.0",
+                "file-loader": "^6.2.0",
+                "fs-extra": "^10.1.0",
+                "html-minifier-terser": "^6.1.0",
+                "html-tags": "^3.2.0",
+                "html-webpack-plugin": "^5.5.0",
+                "import-fresh": "^3.3.0",
+                "leven": "^3.1.0",
+                "lodash": "^4.17.21",
+                "mini-css-extract-plugin": "^2.6.1",
+                "postcss": "^8.4.14",
+                "postcss-loader": "^7.0.0",
+                "prompts": "^2.4.2",
+                "react-dev-utils": "^12.0.1",
+                "react-helmet-async": "^1.3.0",
+                "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
+                "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
+                "react-router": "^5.3.3",
+                "react-router-config": "^5.1.1",
+                "react-router-dom": "^5.3.3",
+                "rtl-detect": "^1.0.4",
+                "semver": "^7.3.7",
+                "serve-handler": "^6.1.3",
+                "shelljs": "^0.8.5",
+                "terser-webpack-plugin": "^5.3.3",
+                "tslib": "^2.4.0",
+                "update-notifier": "^5.1.0",
+                "url-loader": "^4.1.1",
+                "wait-on": "^6.0.1",
+                "webpack": "^5.73.0",
+                "webpack-bundle-analyzer": "^4.5.0",
+                "webpack-dev-server": "^4.9.3",
+                "webpack-merge": "^5.8.0",
+                "webpackbar": "^5.0.2"
+              },
+              "dependencies": {
+                "@docusaurus/utils-common": {
+                  "version": "2.4.0",
+                  "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.4.0.tgz",
+                  "integrity": "sha512-zIMf10xuKxddYfLg5cS19x44zud/E9I7lj3+0bv8UIs0aahpErfNrGhijEfJpAfikhQ8tL3m35nH3hJ3sOG82A==",
+                  "requires": {
+                    "tslib": "^2.4.0"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "@docusaurus/theme-translations": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.4.0.tgz",
+          "integrity": "sha512-kEoITnPXzDPUMBHk3+fzEzbopxLD3fR5sDoayNH0vXkpUukA88/aDL1bqkhxWZHA3LOfJ3f0vJbOwmnXW5v85Q==",
+          "requires": {
+            "fs-extra": "^10.1.0",
+            "tslib": "^2.4.0"
+          }
+        },
+        "@docusaurus/types": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.4.0.tgz",
+          "integrity": "sha512-xaBXr+KIPDkIaef06c+i2HeTqVNixB7yFut5fBXPGI2f1rrmEV2vLMznNGsFwvZ5XmA3Quuefd4OGRkdo97Dhw==",
+          "requires": {
+            "@types/history": "^4.7.11",
+            "@types/react": "*",
+            "commander": "^5.1.0",
+            "joi": "^17.6.0",
+            "react-helmet-async": "^1.3.0",
+            "utility-types": "^3.10.0",
+            "webpack": "^5.73.0",
+            "webpack-merge": "^5.8.0"
+          }
+        },
+        "@docusaurus/utils": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.4.0.tgz",
+          "integrity": "sha512-89hLYkvtRX92j+C+ERYTuSUK6nF9bGM32QThcHPg2EDDHVw6FzYQXmX6/p+pU5SDyyx5nBlE4qXR92RxCAOqfg==",
+          "requires": {
+            "@docusaurus/logger": "2.4.0",
+            "@svgr/webpack": "^6.2.1",
+            "escape-string-regexp": "^4.0.0",
+            "file-loader": "^6.2.0",
+            "fs-extra": "^10.1.0",
+            "github-slugger": "^1.4.0",
+            "globby": "^11.1.0",
+            "gray-matter": "^4.0.3",
+            "js-yaml": "^4.1.0",
+            "lodash": "^4.17.21",
+            "micromatch": "^4.0.5",
+            "resolve-pathname": "^3.0.0",
+            "shelljs": "^0.8.5",
+            "tslib": "^2.4.0",
+            "url-loader": "^4.1.1",
+            "webpack": "^5.73.0"
+          }
+        },
+        "@docusaurus/utils-validation": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.4.0.tgz",
+          "integrity": "sha512-IrBsBbbAp6y7mZdJx4S4pIA7dUyWSA0GNosPk6ZJ0fX3uYIEQgcQSGIgTeSC+8xPEx3c16o03en1jSDpgQgz/w==",
+          "requires": {
+            "@docusaurus/logger": "2.4.0",
+            "@docusaurus/utils": "2.4.0",
+            "joi": "^17.6.0",
+            "js-yaml": "^4.1.0",
+            "tslib": "^2.4.0"
+          }
+        }
+      }
+    },
     "dom-converter": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
@@ -17271,9 +17979,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "electron-to-chromium": {
-      "version": "1.4.247",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.247.tgz",
-      "integrity": "sha512-FLs6R4FQE+1JHM0hh3sfdxnYjKvJpHZyhQDjc2qFq/xFvmmRt/TATNToZhrcGUFzpF2XjeiuozrA8lI0PZmYYw=="
+      "version": "1.4.396",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.396.tgz",
+      "integrity": "sha512-pqKTdqp/c5vsrc0xUPYXTDBo9ixZuGY8es4ZOjjd6HD6bFYbu5QA09VoW3fkY4LF1T0zYk86lN6bZnNlBuOpdQ=="
     },
     "emoji-regex": {
       "version": "9.2.2",
@@ -17409,9 +18117,9 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "eta": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/eta/-/eta-1.12.3.tgz",
-      "integrity": "sha512-qHixwbDLtekO/d51Yr4glcaUJCIjGVJyTzuqV4GPlgZo1YpgOKG+avQynErZIYrfM6JIJdtiG2Kox8tbb+DoGg=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/eta/-/eta-2.1.2.tgz",
+      "integrity": "sha512-qWH+mERhihcwKE9+Ah37rLDTP0d3Qc5KEsnEQhvoBowDezVI2F6+bqjRBVY+auUYOUb94MI0x5fllZs+CWVRRQ=="
     },
     "etag": {
       "version": "1.8.1",
@@ -17723,9 +18431,9 @@
       }
     },
     "flux": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.3.tgz",
-      "integrity": "sha512-yKAbrp7JhZhj6uiT1FTuVMlIAT1J4jqEyBpFApi1kxpGZCvacMVc/t1pMQyotqHhAgvoE3bNvAykhCo2CLjnYw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.4.tgz",
+      "integrity": "sha512-NCj3XlayA2UsapRpM7va6wU1+9rE5FIL7qoMcmxWHRzbp0yujihMBm9BBHZ1MDIk5h5o2Bl6eGiCe8rYELAmYw==",
       "requires": {
         "fbemitter": "^3.0.0",
         "fbjs": "^3.0.1"
@@ -18418,9 +19126,9 @@
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
     },
     "infima": {
-      "version": "0.2.0-alpha.42",
-      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.42.tgz",
-      "integrity": "sha512-ift8OXNbQQwtbIt6z16KnSWP7uJ/SysSMFI4F87MNRTicypfl4Pv3E2OGVv6N3nSZFJvA8imYulCBS64iyHYww=="
+      "version": "0.2.0-alpha.43",
+      "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.43.tgz",
+      "integrity": "sha512-2uw57LvUqW0rK/SWYnd/2rRfxNA5DDNOh33jxF7fy46VWoNhGxiUQyVZHbBMjQ33mQem0cjdDVwgWVAmlRfgyQ=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -18929,6 +19637,11 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
     },
+    "loglevel": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.1.tgz",
+      "integrity": "sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg=="
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -19233,9 +19946,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -19246,9 +19959,9 @@
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
     },
     "node-releases": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
-      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
+      "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w=="
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -19633,22 +20346,22 @@
       }
     },
     "postcss-colormin": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.3.0.tgz",
-      "integrity": "sha512-WdDO4gOFG2Z8n4P8TWBpshnL3JpmNmJwdnfP2gbk2qBA8PWwOYcmjmI/t3CmMeL72a7Hkd+x/Mg9O2/0rD54Pg==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.3.1.tgz",
+      "integrity": "sha512-UsWQG0AqTFQmpBegeLLc1+c3jIqBNB0zlDGRWR+dQ3pRKJL1oeMzyqmH3o2PIfn9MBdNrVPWhDbT769LxCTLJQ==",
       "requires": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "caniuse-api": "^3.0.0",
         "colord": "^2.9.1",
         "postcss-value-parser": "^4.2.0"
       }
     },
     "postcss-convert-values": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.2.tgz",
-      "integrity": "sha512-c6Hzc4GAv95B7suy4udszX9Zy4ETyMCgFPUDtWjdFTKH1SE9eFY/jEpHSwTH1QPuwxHpWslhckUQWbNRM4ho5g==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.3.tgz",
+      "integrity": "sha512-82pC1xkJZtcJEfiLw6UXnXVXScgtBrjlO5CBmuDQc+dlb88ZYheFsjTn40+zBVi3DkfF7iezO0nJUPLcJK3pvA==",
       "requires": {
-        "browserslist": "^4.20.3",
+        "browserslist": "^4.21.4",
         "postcss-value-parser": "^4.2.0"
       }
     },
@@ -19704,20 +20417,20 @@
       }
     },
     "postcss-merge-longhand": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.6.tgz",
-      "integrity": "sha512-6C/UGF/3T5OE2CEbOuX7iNO63dnvqhGZeUnKkDeifebY0XqkkvrctYSZurpNE902LDf2yKwwPFgotnfSoPhQiw==",
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.7.tgz",
+      "integrity": "sha512-YCI9gZB+PLNskrK0BB3/2OzPnGhPkBEwmwhfYk1ilBHYVAZB7/tkTHFBAnCrvBBOmeYyMYw3DMjT55SyxMBzjQ==",
       "requires": {
         "postcss-value-parser": "^4.2.0",
-        "stylehacks": "^5.1.0"
+        "stylehacks": "^5.1.1"
       }
     },
     "postcss-merge-rules": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.2.tgz",
-      "integrity": "sha512-zKMUlnw+zYCWoPN6yhPjtcEdlJaMUZ0WyVcxTAmw3lkkN/NDMRkOkiuctQEoWAOvH7twaxUUdvBWl0d4+hifRQ==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.4.tgz",
+      "integrity": "sha512-0R2IuYpgU93y9lhVbO/OylTtKMVcHb67zjWIfCiKR9rWL3GUk1677LAqD/BcHizukdZEjT8Ru3oHRoAYoJy44g==",
       "requires": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "caniuse-api": "^3.0.0",
         "cssnano-utils": "^3.1.0",
         "postcss-selector-parser": "^6.0.5"
@@ -19742,11 +20455,11 @@
       }
     },
     "postcss-minify-params": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.3.tgz",
-      "integrity": "sha512-bkzpWcjykkqIujNL+EVEPOlLYi/eZ050oImVtHU7b4lFS82jPnsCb44gvC6pxaNt38Els3jWYDHTjHKf0koTgg==",
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.4.tgz",
+      "integrity": "sha512-+mePA3MgdmVmv6g+30rn57USjOGSAyuxUmkfiWpzalZ8aiBkdPYjXWtHuwJGm1v5Ojy0Z0LaSYhHaLJQB0P8Jw==",
       "requires": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "cssnano-utils": "^3.1.0",
         "postcss-value-parser": "^4.2.0"
       }
@@ -19838,11 +20551,11 @@
       }
     },
     "postcss-normalize-unicode": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.0.tgz",
-      "integrity": "sha512-J6M3MizAAZ2dOdSjy2caayJLQT8E8K9XjLce8AUQMwOrCvjCHv24aLC/Lps1R1ylOfol5VIDMaM/Lo9NGlk1SQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.1.tgz",
+      "integrity": "sha512-qnCL5jzkNUmKVhZoENp1mJiGNPcsJCs1aaRmURmeJGES23Z/ajaln+EPTD+rBeNkSryI+2WTdW+lwcVdOikrpA==",
       "requires": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "postcss-value-parser": "^4.2.0"
       }
     },
@@ -19881,11 +20594,11 @@
       }
     },
     "postcss-reduce-initial": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.0.tgz",
-      "integrity": "sha512-5OgTUviz0aeH6MtBjHfbr57tml13PuedK/Ecg8szzd4XRMbYxH4572JFG067z+FqBIf6Zp/d+0581glkvvWMFw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.2.tgz",
+      "integrity": "sha512-dE/y2XRaqAi6OvjzD22pjTUQ8eOfc6m/natGHgKFBK9DxFmIm69YmaRVQrGgFlEfc1HePIurY0TmDeROK05rIg==",
       "requires": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "caniuse-api": "^3.0.0"
       }
     },
@@ -19907,9 +20620,9 @@
       }
     },
     "postcss-sort-media-queries": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/postcss-sort-media-queries/-/postcss-sort-media-queries-4.3.0.tgz",
-      "integrity": "sha512-jAl8gJM2DvuIJiI9sL1CuiHtKM4s5aEIomkU8G3LFvbP+p8i7Sz8VV63uieTgoewGqKbi+hxBTiOKJlB35upCg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/postcss-sort-media-queries/-/postcss-sort-media-queries-4.4.1.tgz",
+      "integrity": "sha512-QDESFzDDGKgpiIh4GYXsSy6sek2yAwQx1JASl5AxBtU1Lq2JfKBljIPNdil989NcSKRQX1ToiaKphImtBuhXWw==",
       "requires": {
         "sort-css-media-queries": "2.1.0"
       }
@@ -20347,11 +21060,11 @@
       }
     },
     "react-textarea-autosize": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.4.tgz",
-      "integrity": "sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.1.tgz",
+      "integrity": "sha512-aD2C+qK6QypknC+lCMzteOdIjoMbNlgSFmJjCV+DrfTPwp59i/it9mMNf2HDzvRjQgKAyBDPyLJhcrzElf2U4Q==",
       "requires": {
-        "@babel/runtime": "^7.10.2",
+        "@babel/runtime": "^7.20.13",
         "use-composed-ref": "^1.3.0",
         "use-latest": "^1.2.1"
       }
@@ -20419,9 +21132,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regenerator-transform": {
       "version": "0.15.0",
@@ -21338,11 +22051,11 @@
       }
     },
     "stylehacks": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.0.tgz",
-      "integrity": "sha512-SzLmvHQTrIWfSgljkQCw2++C9+Ne91d/6Sp92I8c5uHTcy/PgeHamwITIbBW9wnFTY/3ZfSXR9HIL6Ikqmcu6Q==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.1.tgz",
+      "integrity": "sha512-sBpcd5Hx7G6seo7b1LkpttvTz7ikD0LlH5RmdcBNb6fFR0Fl7LQwHDFr300q4cwUqi+IYrFGmsIHieMBfnN/Bw==",
       "requires": {
-        "browserslist": "^4.16.6",
+        "browserslist": "^4.21.4",
         "postcss-selector-parser": "^6.0.4"
       }
     },
@@ -21629,10 +22342,54 @@
       "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
       "peer": true
     },
+    "typesense": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/typesense/-/typesense-1.5.3.tgz",
+      "integrity": "sha512-eLHBP6AHex04tT+q/a7Uc+dFjIuoKTRpvlsNJwVTyedh4n0qnJxbfoLJBCxzhhZn5eITjEK0oWvVZ5byc3E+Ww==",
+      "requires": {
+        "axios": "^0.26.0",
+        "loglevel": "^1.8.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.26.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+          "requires": {
+            "follow-redirects": "^1.14.8"
+          }
+        }
+      }
+    },
+    "typesense-docsearch-css": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/typesense-docsearch-css/-/typesense-docsearch-css-0.4.0.tgz",
+      "integrity": "sha512-hVTJC1Rg2BnNB4kl2Qi4GcgjFmPZY8YGu0aJ5V6iM6vK62yvtE7jObnAc1maYOp33NWFVLPgl/9PlBfWBlN0Dw=="
+    },
+    "typesense-docsearch-react": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/typesense-docsearch-react/-/typesense-docsearch-react-3.4.0.tgz",
+      "integrity": "sha512-87M0ktGiSmJ4m9VpJKC3gD6w31ZhctdB34c6aguLJXsiLDydNF+ipBYuCYE26D47rx/KLk82rsiZwovjaagZnw==",
+      "requires": {
+        "@algolia/autocomplete-core": "1.8.2",
+        "@algolia/autocomplete-preset-algolia": "1.8.2",
+        "typesense": "^1.4.0-3",
+        "typesense-docsearch-css": "^0.4.0",
+        "typesense-instantsearch-adapter": "^2.4.2-1"
+      }
+    },
+    "typesense-instantsearch-adapter": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/typesense-instantsearch-adapter/-/typesense-instantsearch-adapter-2.6.0.tgz",
+      "integrity": "sha512-Z9+L5ba/xodoI3urhyS4rKFQiG98dClhOgUfpNj8oP+w5trqBhqwbJLPPScXwzlmCJWUULPQ5786anGjGMNuxQ==",
+      "requires": {
+        "typesense": "^1.5.3"
+      }
+    },
     "ua-parser-js": {
-      "version": "0.7.31",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
-      "integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ=="
+      "version": "0.7.35",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.35.tgz",
+      "integrity": "sha512-veRf7dawaj9xaWEu9HoTVn5Pggtc/qj+kqTOFvNiN1l0YdxwC1kvel57UCjThjGa3BHBihE8/UJAHI+uQHmd/g=="
     },
     "unherit": {
       "version": "1.1.3",
@@ -21762,9 +22519,9 @@
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
     },
     "update-browserslist-db": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.7.tgz",
-      "integrity": "sha512-iN/XYesmZ2RmmWAiI4Z5rq0YqSiv0brj9Ce9CfhNE4xIW2h+MFxcgkxIzZ+ShkFPUkjU3gQ+3oypadD3RAMtrg==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
+      "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
       "requires": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0"
@@ -21937,6 +22694,12 @@
       "requires": {
         "use-isomorphic-layout-effect": "^1.1.1"
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "2.1.0",
-    "@docusaurus/preset-classic": "2.1.0",
+    "@docusaurus/core": "^2.4.1",
+    "@docusaurus/preset-classic": "^2.4.1",
     "@easyops-cn/docusaurus-search-local": "^0.32.0",
     "@fortawesome/fontawesome-svg-core": "^6.2.0",
     "@fortawesome/free-brands-svg-icons": "^6.2.0",
@@ -23,6 +23,7 @@
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
+    "docusaurus-theme-search-typesense": "^0.11.0",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",
     "react-children-utilities": "^2.8.0",
@@ -30,7 +31,7 @@
     "webpack-font-preload-plugin": "^1.5.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "2.1.0"
+    "@docusaurus/module-type-aliases": "^2.4.1"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
This adds a new search theme that replaces the old one, instead of searching locally, a typesense instance hosted by Odysee will be used to fetch results.

I re-ran the write-translations command to localize the new search plugin.
The descriptions in the `code.json` are only for explanation for the translators and do not need to be changed.