### PR TITLE
Update encoding.mdx

### DIFF
--- a/docs/category-uploading/category-fileuploads/encoding.mdx
+++ b/docs/category-uploading/category-fileuploads/encoding.mdx
@@ -16,7 +16,7 @@ You may have tried uploading a video and gotten this message:
 
 You could upload the video as is, but there’s a high chance of buffering for viewers. You can avoid this by encoding your video.
 
-First, download a program called Handbrake. It’s free to use, open-source, and completely safe.
+First, download a program called Handbrake (or command-line users please scroll to the bottom). Handbrake is free to use, open-source, and completely safe.
 
 You can find it at handbrake.fr.
 
@@ -34,3 +34,11 @@ When you have a video selected, you’ll want to check a few settings.
 ![](/img/en/category-uploading11.png)
 
 If everything is correct, you can select a destination and file name, and hit start. If you encoded at 1080p and the bitrate is still too high, you’ll need to try again at 720p. The majority of the time, the video should be fine at 1080p.
+
+Command-line:
+
+For example,
+
+ffmpeg -i input.mov -c:v libx264 -pix_fmt yuv420p -profile:v baseline -level 3.0 -crf 22 -preset veryslow -vf scale=1280:-2 -c:a aac -movflags +faststart output.mp4 
+
+(from https://gist.github.com/jaydenseric/220c785d6289bcfd7366 )


### PR DESCRIPTION
Command line coders are the guardians of, shall we say, "free computation".  Please do not exclude them from the documentation.  I find that I need to dig up my archived process or refer to other sources (as in the suggested update) because this page was changed.  I understand the team may want a uniform non-intimidating document, but you are making the instructions into almost a black box.  IMO, there should be a more direct path for the more literate to become process-familiar.  I also realize that maybe the team itself does not want to maintain the command-line code even internally due to complexity.  It would be awkward if HandBrake does not offer a code validation button (like luckybackup, for example)... maybe it could be requested if needed.