### PR TITLE
Update streamingdestination.mdx

### DIFF
--- a/docs/category-livestreaming/streamingdestination.mdx
+++ b/docs/category-livestreaming/streamingdestination.mdx
@@ -34,7 +34,7 @@ If everything is correct, you'll click **Ok**.
 
 :::info Note:
 
-To livestream to Odysee using Streamyard, you'll need to have the paid version of Restream.
+To livestream to Odysee using Streamyard, you'll need to have the paid version of Streamyard.
 
 :::
 


### PR DESCRIPTION
Restream seems to have played no part in livestreaming to Odysey via Streamyard. AI Assist seems to insist Restream & Streamyard are compatible because of the claim on this page, thus leading to people wanting to livestream to Odysee paying additional money they could've saved.