### PR TITLE
Remove padding between list item and subitems

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -305,3 +305,7 @@ a {
   border-bottom-right-radius: 0px;
   margin-right: -6px;
 }
+
+li > p {
+  margin-bottom: 0px;
+}


### PR DESCRIPTION
The lists in lists had some padding between parent and child. Removed margin from `li > p` elements, and that seems to work.
Not sure if there is something else to consider? Things else where looked fine.


Red squares  highlight what's removed by change.
![2025-05-06_17-55](https://github.com/user-attachments/assets/39d75729-dff9-423b-b546-6420f15c50a0)
![2025-05-06_17-54](https://github.com/user-attachments/assets/4e3899e7-0191-418a-901a-1dc4ce0a1469)
