### PR TITLE
Update override resolutions for security patches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13535,9 +13535,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
+      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -13554,7 +13554,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -17081,9 +17081,9 @@
       "license": "MIT"
     },
     "node_modules/svgo": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.2.tgz",
-      "integrity": "sha512-TyzE4NVGLUFy+H/Uy4N6c3G0HEeprsVfge6Lmq+0FdQQ/zqoVYB62IsBZORsiL+o96s6ff/V6/3UQo/C0cgCAA==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.3.tgz",
+      "integrity": "sha512-5EZD0pafXX6PphdwOGCiVLDSaV1xyuQao2blHajHLsPxr07q4mmEjdtXEWgG07ae2mIz8Ex2CDXNCTiXhy3Khw==",
       "license": "MIT",
       "dependencies": {
         "commander": "^7.2.0",
@@ -20646,7 +20646,7 @@
         "html-minifier-terser": "^7.2.0",
         "mini-css-extract-plugin": "^2.9.2",
         "null-loader": "^4.0.1",
-        "postcss": "8.5.10",
+        "postcss": "8.5.18",
         "postcss-loader": "^7.3.4",
         "postcss-preset-env": "^10.2.1",
         "terser-webpack-plugin": "^5.3.9",
@@ -20723,7 +20723,7 @@
       "integrity": "sha512-G7WyR2N6SpyUotqhGznERBK+x84uyhfMQM2MmDLs88bw4Flom6TY46HzkRkSEzaP9j80MbTN8naiL1fR17WQug==",
       "requires": {
         "cssnano-preset-advanced": "^6.1.2",
-        "postcss": "8.5.10",
+        "postcss": "8.5.18",
         "postcss-sort-media-queries": "^5.2.0",
         "tslib": "^2.6.0"
       }
@@ -21061,7 +21061,7 @@
         "infima": "0.2.0-alpha.45",
         "lodash": "4.18.1",
         "nprogress": "^0.2.0",
-        "postcss": "8.5.10",
+        "postcss": "8.5.18",
         "prism-react-renderer": "^2.3.0",
         "prismjs": "1.30.0",
         "react-router-dom": "^5.3.4",
@@ -21925,7 +21925,7 @@
       "requires": {
         "cosmiconfig": "^8.1.3",
         "deepmerge": "^4.3.1",
-        "svgo": "^2.8.1"
+        "svgo": "2.8.3"
       }
     },
     "@svgr/webpack": {
@@ -23468,7 +23468,7 @@
       "integrity": "sha512-CTJ+AEQJjq5NzLga5pE39qdiSV56F8ywCIsqNIRF0r7BDgWsN25aazToqAFg7ZrtA/U016xudB3ffgweORxX7g==",
       "requires": {
         "icss-utils": "^5.1.0",
-        "postcss": "8.5.10",
+        "postcss": "8.5.18",
         "postcss-modules-extract-imports": "^3.1.0",
         "postcss-modules-local-by-default": "^4.0.5",
         "postcss-modules-scope": "^3.2.0",
@@ -23485,7 +23485,7 @@
         "@jridgewell/trace-mapping": "^0.3.18",
         "cssnano": "^6.0.1",
         "jest-worker": "^29.4.3",
-        "postcss": "8.5.10",
+        "postcss": "8.5.18",
         "schema-utils": "4.3.3",
         "serialize-javascript": "7.0.5"
       },
@@ -23946,7 +23946,7 @@
             "html-minifier-terser": "^7.2.0",
             "mini-css-extract-plugin": "^2.9.2",
             "null-loader": "^4.0.1",
-            "postcss": "8.5.10",
+            "postcss": "8.5.18",
             "postcss-loader": "^7.3.4",
             "postcss-preset-env": "^10.2.1",
             "terser-webpack-plugin": "^5.3.9",
@@ -24023,7 +24023,7 @@
           "integrity": "sha512-8gBKup94aGttRduABsj7bpPFTX7kbwu+xh3K9NMCF5K4bWBqTFYW+REKHF6iBVDHRJ4grZdIPbvkiHd/XNKRMQ==",
           "requires": {
             "cssnano-preset-advanced": "^6.1.2",
-            "postcss": "8.5.10",
+            "postcss": "8.5.18",
             "postcss-sort-media-queries": "^5.2.0",
             "tslib": "^2.6.0"
           }
@@ -27442,9 +27442,9 @@
       }
     },
     "postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
+      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
       "requires": {
         "nanoid": "3.3.8",
         "picocolors": "^1.1.1",
@@ -28084,7 +28084,7 @@
       "integrity": "sha512-dlrahRmxP22bX6iKEjOM+c8/1p+81asjKT+V5lrgOH944ryx/OHpclnIbGsKVd3uWOXFLYJwCVf0eEkJGvO96g==",
       "requires": {
         "postcss-value-parser": "^4.2.0",
-        "svgo": "^2.8.1"
+        "svgo": "2.8.3"
       }
     },
     "postcss-unique-selectors": {
@@ -28976,7 +28976,7 @@
       "requires": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0",
-        "postcss": "8.5.10",
+        "postcss": "8.5.18",
         "strip-json-comments": "^3.1.1"
       }
     },
@@ -29035,13 +29035,14 @@
       "integrity": "sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==",
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "ajv": "^8.18.0",
+        "ajv": "^8.8.0",
         "ajv-formats": "^2.1.1",
         "ajv-keywords": "5.1.0"
       },
       "dependencies": {
         "ajv": {
-          "version": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+          "version": "8.20.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
           "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
           "requires": {
             "fast-deep-equal": "^3.1.3",
@@ -29629,9 +29630,9 @@
       "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="
     },
     "svgo": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.2.tgz",
-      "integrity": "sha512-TyzE4NVGLUFy+H/Uy4N6c3G0HEeprsVfge6Lmq+0FdQQ/zqoVYB62IsBZORsiL+o96s6ff/V6/3UQo/C0cgCAA==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.3.tgz",
+      "integrity": "sha512-5EZD0pafXX6PphdwOGCiVLDSaV1xyuQao2blHajHLsPxr07q4mmEjdtXEWgG07ae2mIz8Ex2CDXNCTiXhy3Khw==",
       "requires": {
         "commander": "^7.2.0",
         "css-select": "^4.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6450,9 +6450,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -9246,9 +9246,9 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -9793,9 +9793,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -10903,9 +10903,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -12937,9 +12937,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "funding": [
         {
           "type": "github",
@@ -13535,9 +13535,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -13554,7 +13554,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -20646,7 +20646,7 @@
         "html-minifier-terser": "^7.2.0",
         "mini-css-extract-plugin": "^2.9.2",
         "null-loader": "^4.0.1",
-        "postcss": "8.5.18",
+        "postcss": "8.5.23",
         "postcss-loader": "^7.3.4",
         "postcss-preset-env": "^10.2.1",
         "terser-webpack-plugin": "^5.3.9",
@@ -20723,7 +20723,7 @@
       "integrity": "sha512-G7WyR2N6SpyUotqhGznERBK+x84uyhfMQM2MmDLs88bw4Flom6TY46HzkRkSEzaP9j80MbTN8naiL1fR17WQug==",
       "requires": {
         "cssnano-preset-advanced": "^6.1.2",
-        "postcss": "8.5.18",
+        "postcss": "8.5.23",
         "postcss-sort-media-queries": "^5.2.0",
         "tslib": "^2.6.0"
       }
@@ -20850,7 +20850,7 @@
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
-        "js-yaml": "4.3.0",
+        "js-yaml": "4.3.1",
         "lodash": "4.18.1",
         "schema-dts": "^1.1.2",
         "tslib": "^2.6.0",
@@ -21061,7 +21061,7 @@
         "infima": "0.2.0-alpha.45",
         "lodash": "4.18.1",
         "nprogress": "^0.2.0",
-        "postcss": "8.5.18",
+        "postcss": "8.5.23",
         "prism-react-renderer": "^2.3.0",
         "prismjs": "1.30.0",
         "react-router-dom": "^5.3.4",
@@ -21202,7 +21202,7 @@
             "globby": "^11.1.0",
             "gray-matter": "^4.0.3",
             "jiti": "^1.20.0",
-            "js-yaml": "4.3.0",
+            "js-yaml": "4.3.1",
             "lodash": "4.18.1",
             "micromatch": "4.0.8",
             "p-queue": "^6.6.2",
@@ -21233,7 +21233,7 @@
             "@docusaurus/utils-common": "3.9.2",
             "fs-extra": "^11.2.0",
             "joi": ">=17.13.4",
-            "js-yaml": "4.3.0",
+            "js-yaml": "4.3.1",
             "lodash": "4.18.1",
             "tslib": "^2.6.0"
           }
@@ -21335,7 +21335,7 @@
         "globby": "^11.1.0",
         "gray-matter": "^4.0.3",
         "jiti": "^1.20.0",
-        "js-yaml": "4.3.0",
+        "js-yaml": "4.3.1",
         "lodash": "4.18.1",
         "micromatch": "4.0.8",
         "p-queue": "^6.6.2",
@@ -21366,7 +21366,7 @@
         "@docusaurus/utils-common": "3.8.1",
         "fs-extra": "^11.2.0",
         "joi": ">=17.13.4",
-        "js-yaml": "4.3.0",
+        "js-yaml": "4.3.1",
         "lodash": "4.18.1",
         "tslib": "^2.6.0"
       }
@@ -22557,7 +22557,7 @@
           "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
           "requires": {
             "fast-deep-equal": "^3.1.3",
-            "fast-uri": "3.1.4",
+            "fast-uri": "3.1.5",
             "json-schema-traverse": "^1.0.0",
             "require-from-string": "^2.0.2"
           }
@@ -22894,9 +22894,9 @@
       }
     },
     "brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -23408,7 +23408,7 @@
       "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
       "requires": {
         "import-fresh": "^3.3.0",
-        "js-yaml": "4.3.0",
+        "js-yaml": "4.3.1",
         "parse-json": "^5.2.0",
         "path-type": "^4.0.0"
       }
@@ -23468,7 +23468,7 @@
       "integrity": "sha512-CTJ+AEQJjq5NzLga5pE39qdiSV56F8ywCIsqNIRF0r7BDgWsN25aazToqAFg7ZrtA/U016xudB3ffgweORxX7g==",
       "requires": {
         "icss-utils": "^5.1.0",
-        "postcss": "8.5.18",
+        "postcss": "8.5.23",
         "postcss-modules-extract-imports": "^3.1.0",
         "postcss-modules-local-by-default": "^4.0.5",
         "postcss-modules-scope": "^3.2.0",
@@ -23485,7 +23485,7 @@
         "@jridgewell/trace-mapping": "^0.3.18",
         "cssnano": "^6.0.1",
         "jest-worker": "^29.4.3",
-        "postcss": "8.5.18",
+        "postcss": "8.5.23",
         "schema-utils": "4.3.3",
         "serialize-javascript": "7.0.5"
       },
@@ -23496,7 +23496,7 @@
           "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
           "requires": {
             "fast-deep-equal": "^3.1.3",
-            "fast-uri": "3.1.4",
+            "fast-uri": "3.1.5",
             "json-schema-traverse": "^1.0.0",
             "require-from-string": "^2.0.2"
           }
@@ -23946,7 +23946,7 @@
             "html-minifier-terser": "^7.2.0",
             "mini-css-extract-plugin": "^2.9.2",
             "null-loader": "^4.0.1",
-            "postcss": "8.5.18",
+            "postcss": "8.5.23",
             "postcss-loader": "^7.3.4",
             "postcss-preset-env": "^10.2.1",
             "terser-webpack-plugin": "^5.3.9",
@@ -24023,7 +24023,7 @@
           "integrity": "sha512-8gBKup94aGttRduABsj7bpPFTX7kbwu+xh3K9NMCF5K4bWBqTFYW+REKHF6iBVDHRJ4grZdIPbvkiHd/XNKRMQ==",
           "requires": {
             "cssnano-preset-advanced": "^6.1.2",
-            "postcss": "8.5.18",
+            "postcss": "8.5.23",
             "postcss-sort-media-queries": "^5.2.0",
             "tslib": "^2.6.0"
           }
@@ -24099,7 +24099,7 @@
             "@types/react-router-config": "^5.0.7",
             "combine-promises": "^1.1.0",
             "fs-extra": "^11.1.1",
-            "js-yaml": "4.3.0",
+            "js-yaml": "4.3.1",
             "lodash": "4.18.1",
             "schema-dts": "^1.1.2",
             "tslib": "^2.6.0",
@@ -24149,7 +24149,7 @@
             "globby": "^11.1.0",
             "gray-matter": "^4.0.3",
             "jiti": "^1.20.0",
-            "js-yaml": "4.3.0",
+            "js-yaml": "4.3.1",
             "lodash": "4.18.1",
             "micromatch": "4.0.8",
             "p-queue": "^6.6.2",
@@ -24180,7 +24180,7 @@
             "@docusaurus/utils-common": "3.9.2",
             "fs-extra": "^11.2.0",
             "joi": ">=17.13.4",
-            "js-yaml": "4.3.0",
+            "js-yaml": "4.3.1",
             "lodash": "4.18.1",
             "tslib": "^2.6.0"
           }
@@ -24722,9 +24722,9 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="
     },
     "fastq": {
       "version": "1.13.0",
@@ -25055,7 +25055,7 @@
       "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
       "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
       "requires": {
-        "js-yaml": "3.15.0",
+        "js-yaml": "3.15.1",
         "kind-of": "^6.0.2",
         "section-matter": "^1.0.0",
         "strip-bom-string": "^1.0.0"
@@ -25070,9 +25070,9 @@
           }
         },
         "js-yaml": {
-          "version": "3.15.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-          "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+          "version": "3.15.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+          "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
           "requires": {
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"
@@ -25790,9 +25790,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "requires": {
         "argparse": "^2.0.1"
       }
@@ -27033,7 +27033,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "requires": {
-        "brace-expansion": "1.1.16"
+        "brace-expansion": "1.1.18"
       }
     },
     "minimist": {
@@ -27061,9 +27061,9 @@
       }
     },
     "nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w=="
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="
     },
     "negotiator": {
       "version": "0.6.3",
@@ -27442,11 +27442,11 @@
       }
     },
     "postcss": {
-      "version": "8.5.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "requires": {
-        "nanoid": "3.3.8",
+        "nanoid": "3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       }
@@ -28976,7 +28976,7 @@
       "requires": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0",
-        "postcss": "8.5.18",
+        "postcss": "8.5.23",
         "strip-json-comments": "^3.1.1"
       }
     },
@@ -29046,7 +29046,7 @@
           "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
           "requires": {
             "fast-deep-equal": "^3.1.3",
-            "fast-uri": "3.1.4",
+            "fast-uri": "3.1.5",
             "json-schema-traverse": "^1.0.0",
             "require-from-string": "^2.0.2"
           }
@@ -29741,7 +29741,7 @@
           "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
           "requires": {
             "fast-deep-equal": "^3.1.3",
-            "fast-uri": "3.1.4",
+            "fast-uri": "3.1.5",
             "json-schema-traverse": "^1.0.0",
             "require-from-string": "^2.0.2"
           }
@@ -30397,7 +30397,7 @@
           "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
           "requires": {
             "fast-deep-equal": "^3.1.3",
-            "fast-uri": "3.1.4",
+            "fast-uri": "3.1.5",
             "json-schema-traverse": "^1.0.0",
             "require-from-string": "^2.0.2"
           }
@@ -30540,7 +30540,7 @@
           "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
           "requires": {
             "fast-deep-equal": "^3.1.3",
-            "fast-uri": "3.1.4",
+            "fast-uri": "3.1.5",
             "json-schema-traverse": "^1.0.0",
             "require-from-string": "^2.0.2"
           }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "webpack-dev-server": "5.2.6",
     "micromatch": "4.0.8",
     "picomatch": "2.3.2",
-    "postcss": "8.5.10",
+    "postcss": "8.5.18",
     "express": "4.20.0",
     "follow-redirects": "1.16.0",
     "node-forge": "1.4.0",
@@ -77,7 +77,7 @@
     "fast-uri": "3.1.4",
     "send": "0.19.0",
     "uuid": "11.1.1",
-    "svgo": "^2.8.1",
+    "svgo": "2.8.3",
     "yaml": "1.10.3",
     "schema-utils@2.7.0": {
       "ajv": "6.14.0",

--- a/package.json
+++ b/package.json
@@ -35,14 +35,14 @@
   "overrides": {
     "on-headers": "1.1.0",
     "http-proxy-middleware": "2.0.10",
-    "nanoid": "3.3.8",
+    "nanoid": "3.3.17",
     "prismjs": "1.30.0",
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "word-wrap": "1.2.4",
     "webpack-dev-server": "5.2.6",
     "micromatch": "4.0.8",
     "picomatch": "2.3.2",
-    "postcss": "8.5.18",
+    "postcss": "8.5.23",
     "express": "4.20.0",
     "follow-redirects": "1.16.0",
     "node-forge": "1.4.0",
@@ -73,8 +73,8 @@
     "body-parser": "1.20.6",
     "tough-cookie": "4.1.3",
     "cookie": "0.7.2",
-    "brace-expansion": "1.1.16",
-    "fast-uri": "3.1.4",
+    "brace-expansion": "1.1.18",
+    "fast-uri": "3.1.5",
     "send": "0.19.0",
     "uuid": "11.1.1",
     "svgo": "2.8.3",
@@ -104,7 +104,7 @@
       "ajv": "^8.18.0"
     },
     "gray-matter": {
-      "js-yaml": "3.15.0"
+      "js-yaml": "3.15.1"
     }
   },
   "browserslist": {


### PR DESCRIPTION
- svgo: 2.8.3 → 2.8.4 (executable links via namespace/control-char bypass, foreignObject sanitization)
- nanoid: 3.3.17 → 3.3.18 (infinite loop on zero-size custom generators)
- js-yaml: 4.3.1 → 4.3.2 (maxTotalMergeKeys CPU exhaustion on empty merge sources)
- fast-uri: 3.1.5 → 3.1.6 (host confusion, SSRF via IPv6/hostname percent-decoding)
- qs: 6.15.2 → 6.16.0 (array-limit bypass, DoS via attacker-controlled isBuffer)
- joi: >=17.13.4 → >=18.2.5 (prototype pollution via __proto__ language key, rename template prototype set)
- browserslist: add 4.28.7 (crash/prototype write via untrusted stats.json, OOM via unbounded cache)
- colord: add 2.9.4 (slow rejection of oversized malformed color strings)
- baseline-browser-mapping: add 2.11.0 (DoS via process termination on invalid input)
- postcss-selector-parser: add 7.1.3 (DoS through uncontrolled AST recursion)

Remaining known unresolvable:

- image-size: no patch available; transitive via @docusaurus/mdx-loader
- js-yaml@3.x: pinned by gray-matter (<=0.3.5) → @docusaurus/utils; upstream must migrate to js-yaml@4